### PR TITLE
test AdmArea.get_road_network

### DIFF
--- a/gpbp/layers.py
+++ b/gpbp/layers.py
@@ -160,10 +160,10 @@ class AdmArea:
         )
         self.road_network = ox.add_edge_travel_times(self.road_network)
         time = nx.get_edge_attributes(self.road_network, "travel_time")
-        time_min = dict(
+        time_in_minutes = dict(
             zip(list(time.keys()), list(map(lambda x: round(x / 60, 2), time.values())))
         )
-        nx.set_edge_attributes(self.road_network, time_min, "travel_time")
+        nx.set_edge_attributes(self.road_network, time_in_minutes, "travel_time")
 
     def get_rwi(self, method: str) -> None:
         """


### PR DESCRIPTION
I used the networks created by Catalina to test `get_road_network`. I only mocked `ox.get_graph_from_polygon` because I think that's the only method that tries to get data from the internet. I believe the others only perform computations based on the dowloaded data.