### PR TITLE
Philipp/fix index isopolygons

### DIFF
--- a/examples/pisa_showcase_osm.ipynb
+++ b/examples/pisa_showcase_osm.ipynb
@@ -25,7 +25,13 @@
     "from pisa.administrative_area import AdministrativeArea\n",
     "from pisa.facilities import Facilities\n",
     "from pisa.population import WorldpopPopulation\n",
-    "from pisa.population_served_by_isopolygons import get_population_served_by_isopolygons\n"
+    "from pisa.population_served_by_isopolygons import get_population_served_by_isopolygons\n",
+    "from pisa.visualisation import (\n",
+    "    plot_facilities,\n",
+    "    plot_isochrones,\n",
+    "    plot_population,\n",
+    "    plot_population_heatmap,\n",
+    ")\n"
    ]
   },
   {
@@ -110,6 +116,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f7a91dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_facilities(hospitals_df, baucau)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "6abc7d94",
    "metadata": {},
@@ -157,6 +173,26 @@
     ").get_population_gdf()\n",
     "\n",
     "population_gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "021481ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_population_heatmap(population_gdf, baucau)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5622b259",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_population(population_gdf, baucau, random_sample_n=1000)"
    ]
   },
   {
@@ -240,6 +276,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7dfcf0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "isopolygons_existing_facilities.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e54aa6e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_isochrones(isopolygons_existing_facilities, baucau)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "e2e57bd5",
    "metadata": {},
@@ -260,40 +316,6 @@
     "    distance_values=DISTANCE_VALUES,\n",
     "    road_network=road_network,\n",
     ").calculate_isopolygons()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fff6688b",
-   "metadata": {},
-   "source": [
-    "### **HOTFIX!!**\n",
-    "\n",
-    "Eliminate next 2 cells when index in OsmIsopolygonCalculator and OsmIsopolygonCalculatorAlternative are fixed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c7dfcf0e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "isopolygons_existing_facilities.reset_index(drop=True, inplace=True)\n",
-    "\n",
-    "isopolygons_existing_facilities.head(2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f23a1263",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "isopolygons_potential_facilities.reset_index(drop=True, inplace=True)\n",
-    "\n",
-    "isopolygons_potential_facilities.head()"
    ]
   },
   {
@@ -393,14 +415,6 @@
    "source": [
     "solutions"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b2bf3d8b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/pisa/isopolygons.py
+++ b/pisa/isopolygons.py
@@ -135,11 +135,17 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         self.edge_buff = edge_buffer
 
         # Find the nearest node in the road network and create a dictionary to store the match with the respective facility
-        nearest_nodes = ox.distance.nearest_nodes(
+        nearest_nodes, distance_to_nearest_nodes = ox.distance.nearest_nodes(
             G=self.road_network,
             X=self.facilities_df.longitude.values,
             Y=self.facilities_df.latitude.values,
+            return_dist=True,
         )
+        if any(distance_to_nearest_nodes > 10000):
+            logger.warning(
+                "Some facilities are more than 10 km away from the nearest node on the OSM road network."
+            )
+
         self.nearest_nodes_dict = {
             facility_id: node
             for facility_id, node in zip(self.facilities_df.index, nearest_nodes)
@@ -299,11 +305,16 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
         self.buffer = buffer
 
         # Find the nearest node in the road network and create a dictionary to store the match with the respective facility
-        nearest_nodes = ox.distance.nearest_nodes(
+        nearest_nodes, distance_to_nearest_nodes = ox.distance.nearest_nodes(
             G=self.road_network,
             X=self.facilities_df.longitude.values,
             Y=self.facilities_df.latitude.values,
+            return_dist=True,
         )
+        if any(distance_to_nearest_nodes > 10000):
+            logger.warning(
+                "Some facilities are more than 10 km away from the nearest node on the OSM road network."
+            )
         self.nearest_nodes_dict = {
             facility_id: node
             for facility_id, node in zip(self.facilities_df.index, nearest_nodes)
@@ -560,10 +571,4 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
     def _validate_mapbox_token_not_empty(mapbox_api_token: str) -> str:
         if not mapbox_api_token:
             raise ValueError("Mapbox API token is required")
-        return mapbox_api_token
-        return mapbox_api_token
-        return mapbox_api_token
-        return mapbox_api_token
-        return mapbox_api_token
-        return mapbox_api_token
         return mapbox_api_token

--- a/pisa/isopolygons.py
+++ b/pisa/isopolygons.py
@@ -58,9 +58,7 @@ class IsopolygonCalculator(ABC):
             "longitude" not in facilities_df.columns
             or "latitude" not in facilities_df.columns
         ):
-            raise ValueError(
-                "facilities_df must have columns 'longitude' and 'latitude'"
-            )
+            raise ValueError("facilities_df must have columns 'longitude' and 'latitude'")
 
         if len(facilities_df) == 0:
             raise ValueError("facilities_df must have at least one row")
@@ -136,12 +134,17 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         self.node_buff = node_buffer
         self.edge_buff = edge_buffer
 
-        # Find the nearest node in the road network for each facility
-        self.nearest_nodes = ox.distance.nearest_nodes(
+        # Find the nearest node in the road network and create a dictionary to store the match with the respective facility
+        nearest_nodes = ox.distance.nearest_nodes(
             G=self.road_network,
             X=self.facilities_df.longitude.values,
             Y=self.facilities_df.latitude.values,
         )
+        self.nearest_nodes_dict = {
+            facility_id: node
+            for facility_id, node in zip(self.facilities_df.index, nearest_nodes)
+        }
+        self.facility_id_name = self.facilities_df.index.name
 
     def calculate_isopolygons(self) -> DataFrame:
         """Calculates isopolygons for each facility at different distances (distance_values).
@@ -152,36 +155,34 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         N.B.: distances will be computed with respect to the nearest node to the facility,
         not the facility itself."""
 
-        index = pd.Index(self.nearest_nodes, name="nearest_node")
+        # Initialize an empty DataFrame to store isopolygons
+        index = self.nearest_nodes_dict.keys()
         columns = [f"ID_{d}" for d in self.distance_values]
         isopolygons = DataFrame(index=index, columns=columns)
+        isopolygons.index.name = self.facility_id_name
 
         # Construct isopolygon for each distance value
         for distance_value in self.distance_values:
-
-            for road_node in self.nearest_nodes:
-
+            for facility_id, road_node in self.nearest_nodes_dict.items():
                 nodes_gdf, edges_gdf = self._get_skeleton_nodes_and_edges(
                     self.road_network, road_node, distance_value, self.distance_type
                 )
 
                 try:
-
                     new_isopolygon = self._add_buffer_to_isopolygon_skeleton(
                         nodes_gdf=nodes_gdf,
                         edges_gdf=edges_gdf,
                         node_buffer=self.node_buff,
                         edge_buffer=self.edge_buff,
                     )
-                    isopolygons.loc[road_node, "ID_" + str(distance_value)] = (
+                    isopolygons.loc[facility_id, "ID_" + str(distance_value)] = (
                         new_isopolygon
                     )
 
-                except (
-                    AttributeError
-                ):  # Probably trying to catch 'MultiPolygon' object has no attribute 'exterior' from _inflate_skeleton, but it wasn't specified in the code before
-
-                    logger.info(f"problem with node {road_node}")  # stops execution
+                except AttributeError:  # Probably trying to catch 'MultiPolygon' object has no attribute 'exterior' from _inflate_skeleton, but it wasn't specified in the code before
+                    logger.info(
+                        f"problem with node {road_node} belonging to facility {facility_id}"
+                    )  # stops execution
 
         return isopolygons
 
@@ -297,12 +298,17 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
         self.road_network = road_network
         self.buffer = buffer
 
-        # Find the nearest node in the road network for each facility
-        self.nearest_nodes = ox.distance.nearest_nodes(
+        # Find the nearest node in the road network and create a dictionary to store the match with the respective facility
+        nearest_nodes = ox.distance.nearest_nodes(
             G=self.road_network,
             X=self.facilities_df.longitude.values,
             Y=self.facilities_df.latitude.values,
         )
+        self.nearest_nodes_dict = {
+            facility_id: node
+            for facility_id, node in zip(self.facilities_df.index, nearest_nodes)
+        }
+        self.facility_id_name = self.facilities_df.index.name
 
     def calculate_isopolygons(self) -> DataFrame:
         """
@@ -316,18 +322,18 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
 
         """
 
-        index = pd.Index(self.nearest_nodes, name="nearest_node")
+        index = self.nearest_nodes_dict.keys()
         columns = [f"ID_{d}" for d in self.distance_values]
         isopolygons = pd.DataFrame(index=index, columns=columns)
+        isopolygons.index.name = self.facility_id_name
 
         for distance_value in self.distance_values:
-
             # Get skeletons for all nodes at this distance value
             skeletons = [
                 self._get_skeleton_nodes_and_edges(
                     self.road_network, node, distance_value, self.distance_type
                 )
-                for node in self.nearest_nodes
+                for node in self.nearest_nodes_dict.values()
             ]
 
             # "Inflate" skeletons to isopolygons at this distance value
@@ -395,16 +401,13 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
         mapbox_api_token: str,
         base_url: str = "https://api.mapbox.com/isochrone/v1/",
     ):
-
         self.mapbox_api_token = self._validate_mapbox_token_not_empty(mapbox_api_token)
 
         self.route_profile = validate_mode_of_transport(mode_of_transport)
 
         super().__init__(facilities_df, distance_type, distance_values)
 
-        self.distance_values = self._validate_mapbox_distance_values(
-            self.distance_values
-        )
+        self.distance_values = self._validate_mapbox_distance_values(self.distance_values)
 
         self.base_url = base_url
 
@@ -557,4 +560,10 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
     def _validate_mapbox_token_not_empty(mapbox_api_token: str) -> str:
         if not mapbox_api_token:
             raise ValueError("Mapbox API token is required")
+        return mapbox_api_token
+        return mapbox_api_token
+        return mapbox_api_token
+        return mapbox_api_token
+        return mapbox_api_token
+        return mapbox_api_token
         return mapbox_api_token

--- a/pisa/isopolygons.py
+++ b/pisa/isopolygons.py
@@ -142,15 +142,22 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
             return_dist=True,
         )
         if any(distance_to_nearest_nodes > 10000):
+            import numpy as np
+
+            high_distance_indices = np.where(distance_to_nearest_nodes > 10000)
+            far_from_road_facilities = self.facilities_df.iloc[high_distance_indices]
+            far_from_road_facilities["nearest_road_node"] = nearest_nodes[
+                high_distance_indices
+            ]
+
             logger.warning(
-                "Some facilities are more than 10 km away from the nearest node on the OSM road network. It makes sense to compare your results with the Mapbox API."
+                f"Some facilities are more than 10 km away from the nearest node on the OSM road network. The facilities and their nearest nodes are: {far_from_road_facilities[['nearest_road_node']]} \n It makes sense to visually inspect these in a notebook or compare your results with the Mapbox API."
             )
 
         self.nearest_nodes_dict = {
             facility_id: node
             for facility_id, node in zip(self.facilities_df.index, nearest_nodes)
         }
-        self.facility_id_name = self.facilities_df.index.name
 
     def calculate_isopolygons(self) -> DataFrame:
         """Calculates isopolygons for each facility at different distances (distance_values).
@@ -165,7 +172,7 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         index = self.nearest_nodes_dict.keys()
         columns = [f"ID_{d}" for d in self.distance_values]
         isopolygons = DataFrame(index=index, columns=columns)
-        isopolygons.index.name = self.facility_id_name
+        isopolygons.index.name = self.facilities_df.index.name
 
         # Construct isopolygon for each distance value
         for distance_value in self.distance_values:
@@ -312,14 +319,21 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
             return_dist=True,
         )
         if any(distance_to_nearest_nodes > 10000):
+            import numpy as np
+
+            high_distance_indices = np.where(distance_to_nearest_nodes > 10000)
+            far_from_road_facilities = self.facilities_df.iloc[high_distance_indices]
+            far_from_road_facilities["nearest_road_node"] = nearest_nodes[
+                high_distance_indices
+            ]
+
             logger.warning(
-                "Some facilities are more than 10 km away from the nearest node on the OSM road network. It makes sense to compare your results with the Mapbox API."
+                f"Some facilities are more than 10 km away from the nearest node on the OSM road network. The facilities and their nearest nodes are: {far_from_road_facilities[['nearest_road_node']]} \n It makes sense to visually inspect these in a notebook or compare your results with the Mapbox API."
             )
         self.nearest_nodes_dict = {
             facility_id: node
             for facility_id, node in zip(self.facilities_df.index, nearest_nodes)
         }
-        self.facility_id_name = self.facilities_df.index.name
 
     def calculate_isopolygons(self) -> DataFrame:
         """
@@ -336,7 +350,7 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
         index = self.nearest_nodes_dict.keys()
         columns = [f"ID_{d}" for d in self.distance_values]
         isopolygons = pd.DataFrame(index=index, columns=columns)
-        isopolygons.index.name = self.facility_id_name
+        isopolygons.index.name = self.facilities_df.index.name
 
         for distance_value in self.distance_values:
             # Get skeletons for all nodes at this distance value

--- a/pisa/isopolygons.py
+++ b/pisa/isopolygons.py
@@ -143,7 +143,7 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         )
         if any(distance_to_nearest_nodes > 10000):
             logger.warning(
-                "Some facilities are more than 10 km away from the nearest node on the OSM road network."
+                "Some facilities are more than 10 km away from the nearest node on the OSM road network. It makes sense to compare your results with the Mapbox API."
             )
 
         self.nearest_nodes_dict = {
@@ -313,7 +313,7 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
         )
         if any(distance_to_nearest_nodes > 10000):
             logger.warning(
-                "Some facilities are more than 10 km away from the nearest node on the OSM road network."
+                "Some facilities are more than 10 km away from the nearest node on the OSM road network. It makes sense to compare your results with the Mapbox API."
             )
         self.nearest_nodes_dict = {
             facility_id: node

--- a/tests/test_isopolygons_osm_alternative.py
+++ b/tests/test_isopolygons_osm_alternative.py
@@ -15,15 +15,14 @@ def dataframe_with_lon_and_lat() -> pd.DataFrame:
         (-122.2314069, 37.7687054),  # closest node 5909483619
         (-122.23124, 37.76876),  # closest node 5909483625
     ]
+    osmids = [5909483619, 5909483625]
 
-    return pd.DataFrame(points, columns=["longitude", "latitude"])
+    return pd.DataFrame(points, columns=["longitude", "latitude"], index=osmids)
 
 
 class TestOsmCalculateIsopolygonsAlternative:
-
     @pytest.fixture(autouse=True)
     def setup(self, dataframe_with_lon_and_lat):
-
         self.graph = ox.load_graphml(
             "tests/test_data/walk_network_4_nodes_6_edges.graphml"
         )
@@ -41,15 +40,16 @@ class TestOsmCalculateIsopolygonsAlternative:
         self.isopolygons = self.isopolygon_calculator.calculate_isopolygons()
 
     def test_format(self):
-
         np.array_equal(
-            self.isopolygon_calculator.nearest_nodes, [5909483625, 5909483619]
+            self.isopolygon_calculator.nearest_nodes_dict.keys(), [5909483625, 5909483619]
         )
 
         assert self.isopolygons.shape == (
             2,
             3,
-        ), "The output should have two rows (one per node in nearest_nodes) and three columns (one per distance)"
+        ), (
+            "The output should have two rows (one per node in nearest_nodes) and three columns (one per distance)"
+        )
 
         assert list(self.isopolygons.columns) == ["ID_5", "ID_20", "ID_50"]
 
@@ -57,17 +57,15 @@ class TestOsmCalculateIsopolygonsAlternative:
         assert list(self.isopolygons.index) == [5909483619, 5909483625]
 
     def test_nodes_in_isopolygon_5909483619_5(self):
-
         # The only node less than 5m away from 5909483619 is itself
         nodes_within = self.graph_nodes[
             self.graph_nodes.within(self.isopolygons.loc[5909483619, "ID_5"])
         ]
-        assert set(nodes_within.index) == {
-            5909483619
-        }, "The only node in this isopolygon should be 5909483619"
+        assert set(nodes_within.index) == {5909483619}, (
+            "The only node in this isopolygon should be 5909483619"
+        )
 
     def test_no_edges_in_isopolygon_5909483619_5(self):
-
         # Since the only node less than 5m away from 5909483619 is itself, there
         # are no edges from the road network in this isopolygon
 
@@ -76,7 +74,6 @@ class TestOsmCalculateIsopolygonsAlternative:
         ), "There should be no edges in this isopolygon"
 
     def test_nodes_in_isopolygon_5909483619_50(self):
-
         nodes_within = self.graph_nodes[
             self.graph_nodes.within(self.isopolygons.loc[5909483619, "ID_50"])
         ]
@@ -86,10 +83,11 @@ class TestOsmCalculateIsopolygonsAlternative:
             5909483619,
             5909483625,
             5909483636,
-        }, "Nodes 5909483619, 5909483625 and 5909483636 should be in this isopolygon, but 5909483569 should not"
+        }, (
+            "Nodes 5909483619, 5909483625 and 5909483636 should be in this isopolygon, but 5909483569 should not"
+        )
 
     def test_nodes_in_isopolygon_5909483625_50(self):
-
         nodes_within = self.graph_nodes[
             self.graph_nodes.within(self.isopolygons.loc[5909483625, "ID_50"])
         ]
@@ -98,11 +96,12 @@ class TestOsmCalculateIsopolygonsAlternative:
         assert set(nodes_within.index) == {
             5909483619,
             5909483625,
-        }, "Nodes 5909483619 and 5909483625 should be in this isopolygon, but 5909483636 and 5909483569 should not"
+        }, (
+            "Nodes 5909483619 and 5909483625 should be in this isopolygon, but 5909483636 and 5909483569 should not"
+        )
 
 
 class TestGetSkeletonNodesAndEdgesAlternative:
-
     @pytest.fixture(autouse=True)
     def setup(self):
         """All tests use the same graph"""
@@ -127,7 +126,6 @@ class TestGetSkeletonNodesAndEdgesAlternative:
         assert skeleton.within(self.road_nodes.loc[5909483619, "geometry"])
 
     def test_nodes_and_edges(self):
-
         skeleton = OsmIsopolygonCalculatorAlternative._get_skeleton_nodes_and_edges(
             self.road_network,
             center_node=5909483619,


### PR DESCRIPTION
Save the ID of the nearest node on the road network and the original facility id together when creating the isopolygons. Then pass the ID of the original facility to the isopolygon dataframe (like in Mapbox).

Add a logger warning if the nearest node is more than 10km away from the original location of the facility.
Adjust the tests
