### PR TITLE
streamlit fixes

### DIFF
--- a/pisa_app/tab_optimization.py
+++ b/pisa_app/tab_optimization.py
@@ -46,6 +46,8 @@ def pisa_optimization(ss):
             if ss.potential_facilities_gdf is not None:
                 max_value_pot = ss.potential_facilities_gdf.shape[0]
         options = np.array([5, 10, 20, 50, 100, 150, 200, 250])
+        if 'max_value_pot' in locals() and max_value_pot < 5 and max_value_pot > 0:
+            options = np.append(options, max_value_pot)
         st.selectbox(
             "Budget (max number of potential locations to be built)",
             options=options[options <= max_value_pot],

--- a/pisa_app/tab_population_data.py
+++ b/pisa_app/tab_population_data.py
@@ -12,7 +12,7 @@ def population_data(ss):
         "Pick the population resolution (larger values increase accuracy)",
         min_value=1,
         max_value=5,
-        value=5,
+        value=1,
         step=1,
     )
 


### PR DESCRIPTION
- Set default value for population resolution to 1
- Add maximum amount of potential facilities as option to the budget when it is smaller than 5, so budget will always be minimally the maximum nr of potential facilities (previously having less than 5 potential facilities would mean optimisation in streamlit would not run)