### PR TITLE
Enhance module documentation and type hinting

### DIFF
--- a/pisa/administrative_area.py
+++ b/pisa/administrative_area.py
@@ -124,10 +124,6 @@ class AdministrativeArea:
     def get_admin_area_names(self) -> list[str]:
         """Retrieve the names of all administrative areas for the specified level.
         
-        Parameters
-        ----------
-        None
-        
         Returns
         -------
         list of str
@@ -175,10 +171,6 @@ class AdministrativeArea:
 
     def get_iso3_country_code(self) -> str:
         """Retrieve the ISO 3166-1 alpha-3 country code for the country.
-        
-        Parameters
-        ----------
-        None
         
         Returns
         -------

--- a/pisa/administrative_area.py
+++ b/pisa/administrative_area.py
@@ -11,20 +11,33 @@ logger = logging.getLogger(__name__)
 
 class AdministrativeArea:
     """Get the boundaries of administrative areas for a specified country.
-
-    The administrative area level is specified by an integer, where 0 is the country level, 
-    1 is the next broadest level (e.g. states or provinces), and so on.
-
-    It is possible to get the geometry of a specific administrative area by name.
-
-    Example usage:
     
-    ```python
-    timor_leste = AdministrativeArea("Timor-Leste", admin_level=1)
-    print(timor_leste.get_admin_area_names())
-    baucau_boundaries = timor_leste.get_admin_area_boundaries("Baucau")
-    timor_leste_country_code = timor_leste.get_iso3_country_code()
-    ```
+    This class provides functionality to retrieve administrative area boundaries
+    from the GADM (Global Administrative Areas) database for a specified country.
+    
+    The administrative area level is specified by an integer, where 0 is the country level, 
+    1 is the next broadest level (e.g., states or provinces), and so on.
+    
+    Parameters
+    ----------
+    country_name : str
+        The name of the country for which to retrieve administrative areas
+    admin_level : int
+        The administrative area level to retrieve (0 for country, 1 for first-level divisions, etc.)
+    
+    Examples
+    --------
+    >>> # Create an administrative area object for Timor-Leste at province level
+    >>> timor_leste = AdministrativeArea("Timor-Leste", admin_level=1)
+    >>> 
+    >>> # Get a list of all administrative areas at this level
+    >>> print(timor_leste.get_admin_area_names())
+    >>> 
+    >>> # Get the boundaries for a specific administrative area
+    >>> baucau_boundaries = timor_leste.get_admin_area_boundaries("Baucau")
+    >>> 
+    >>> # Get the ISO3 country code for the country
+    >>> timor_leste_country_code = timor_leste.get_iso3_country_code()
     """
 
     def __init__(
@@ -38,16 +51,27 @@ class AdministrativeArea:
 
     @staticmethod
     def _get_pycountry_from_country_name(country_name: str):
-        """Validates country name using fuzzy matching and returns pycountry object.
+        """Validate country name using fuzzy matching and return pycountry object.
         
-        Args:
-            country_name: Name of the country to validate
+        Parameters
+        ----------
+        country_name : str
+            Name of the country to validate
         
-        Returns:
-            pycountry.db.Country object
+        Returns
+        -------
+        pycountry.db.Country
+            Country object from the pycountry library
             
-        Raises:
-            Exception: If country name is invalid or not found
+        Raises
+        ------
+        ValueError
+            If the country name is invalid or not found
+        
+        Notes
+        -----
+        This method performs an exact match first, and if unsuccessful,
+        attempts a fuzzy search to suggest possible matches.
         """
         logger.info(f"Validating country name: {country_name}")
         country = pycountry.countries.get(name=country_name)
@@ -65,14 +89,25 @@ class AdministrativeArea:
     
     @staticmethod
     def _download_admin_areas(country, admin_level: int) -> GeoDataFrame:
-        """Downloads and returns all administrative areas of specified level for a country.
+        """Download and return all administrative areas of specified level for a country.
         
-        Args:
-            country_name: Name of the country
-            admin_level: Administrative area level (0 for country, 1 for first level divisions, etc.)
+        Parameters
+        ----------
+        country : pycountry.db.Country
+            Country object from the pycountry library
+        admin_level : int
+            Administrative area level (0 for country, 1 for first-level divisions, etc.)
         
-        Returns:
-            GeoDataFrame containing all administrative areas of the specified level
+        Returns
+        -------
+        geopandas.GeoDataFrame
+            GeoDataFrame containing all administrative areas of the specified level with their
+            geometries and associated attributes
+            
+        Notes
+        -----
+        This method uses the GADM (Global Administrative Areas) database version 4.0
+        to retrieve administrative boundaries.
         """
         logger.info(f"Retrieving boundaries of all administrative areas of level {admin_level} for country {country.name}")
         downloader = GADMDownloader(version="4.0")
@@ -82,9 +117,15 @@ class AdministrativeArea:
         )
     
     def get_admin_area_names(self) -> list[str]:
-        """Retrieves the names of all administrative areas for the specified level.
+        """Retrieve the names of all administrative areas for the specified level.
         
-        Returns:
+        Parameters
+        ----------
+        None
+        
+        Returns
+        -------
+        list of str
             List of administrative area names at the specified level.
             For admin_level=0, returns just the country name.
         """
@@ -94,16 +135,23 @@ class AdministrativeArea:
         return self.all_admin_areas_gdf[f"NAME_{self.admin_level}"].tolist()
 
     def get_admin_area_boundaries(self, admin_area_name: str) -> Polygon | MultiPolygon:
-        """Returns the boundary geometry for the specified administrative area.
+        """Return the boundary geometry for the specified administrative area.
         
-        Args:
-            admin_area_name: Name of the administrative area to retrieve boundaries for
+        Parameters
+        ----------
+        admin_area_name : str
+            Name of the administrative area to retrieve boundaries for.
+            For admin_level=0, this parameter is ignored and the country boundary is returned.
         
-        Returns:
-            Polygon or MultiPolygon representing the administrative area boundaries
+        Returns
+        -------
+        shapely.geometry.Polygon or shapely.geometry.MultiPolygon
+            Geometry representing the administrative area boundaries
             
-        Raises:
-            Exception: If admin_area_name is not set or not found in the data
+        Raises
+        ------
+        ValueError
+            If admin_area_name is not found in the available administrative areas
         """
         if self.admin_level == 0:
             return self.all_admin_areas_gdf.geometry.iloc[0]
@@ -121,10 +169,15 @@ class AdministrativeArea:
         return filtered.geometry.iloc[0]
 
     def get_iso3_country_code(self) -> str:
-        """
-        Retrieve the ISO 3166-1 alpha-3 country code for the country associated with this instance.
-
-        Returns:
-            str: The ISO 3166-1 alpha-3 country code in lowercase.
+        """Retrieve the ISO 3166-1 alpha-3 country code for the country.
+        
+        Parameters
+        ----------
+        None
+        
+        Returns
+        -------
+        str
+            The ISO 3166-1 alpha-3 country code in lowercase (e.g., 'tls' for Timor-Leste)
         """
         return self.country.alpha_3.lower()

--- a/pisa/administrative_area.py
+++ b/pisa/administrative_area.py
@@ -12,6 +12,24 @@ AdministrativeArea : Class for retrieving and managing administrative area bound
 The module supports fuzzy matching of country names, downloading boundary data at different administrative levels,
 and accessing specific regions within countries.
 
+Examples
+--------
+Retrieve administrative boundaries for a country and its subdivisions:
+
+>>> from pisa.administrative_area import AdministrativeArea
+>>>
+>>> # Get country-level boundaries
+>>> country = AdministrativeArea("Timor-Leste", admin_level=0)
+>>> country_boundary = country.get_admin_area_boundaries("Timor-Leste")
+>>> 
+>>> # Get province-level boundaries
+>>> provinces = AdministrativeArea("Timor-Leste", admin_level=1)
+>>> province_names = provinces.get_admin_area_names()
+>>> print(f"Provinces in Timor-Leste: {', '.join(province_names)}")
+>>> 
+>>> # Get boundary for a specific province
+>>> baucau_boundary = provinces.get_admin_area_boundaries("Baucau")
+
 See Also
 --------
 facilities : Module for working with facility locations

--- a/pisa/administrative_area.py
+++ b/pisa/administrative_area.py
@@ -24,6 +24,11 @@ class AdministrativeArea:
         The name of the country for which to retrieve administrative areas
     admin_level : int
         The administrative area level to retrieve (0 for country, 1 for first-level divisions, etc.)
+        
+    See Also
+    --------
+    Facilities : Class for retrieving facilities within administrative areas
+    Population : Class for retrieving population data within administrative areas
     
     Examples
     --------

--- a/pisa/administrative_area.py
+++ b/pisa/administrative_area.py
@@ -93,7 +93,7 @@ class AdministrativeArea:
         self.all_admin_areas_gdf = self._download_admin_areas(country=self.country, admin_level=self.admin_level)
 
     @staticmethod
-    def _get_pycountry_from_country_name(country_name: str):
+    def _get_pycountry_from_country_name(country_name: str) -> object:
         """Validate country name using fuzzy matching and return pycountry object.
         
         Parameters

--- a/pisa/administrative_area.py
+++ b/pisa/administrative_area.py
@@ -1,3 +1,23 @@
+"""Administrative boundaries retrieval and management module.
+
+This module provides functionality to access and work with administrative area boundaries at various levels 
+(countries, provinces, districts, etc.) using the GADM (Global Administrative Areas) database. 
+It enables the retrieval of geographic boundaries for specific administrative areas within countries, 
+which is a fundamental component for spatial analysis in public infrastructure planning.
+
+Classes
+-------
+AdministrativeArea : Class for retrieving and managing administrative area boundaries
+
+The module supports fuzzy matching of country names, downloading boundary data at different administrative levels,
+and accessing specific regions within countries.
+
+See Also
+--------
+facilities : Module for working with facility locations
+population : Module for population data within administrative areas
+"""
+
 import logging
 
 import pycountry

--- a/pisa/constants.py
+++ b/pisa/constants.py
@@ -1,4 +1,20 @@
-"""Constants used throughout the PISA package."""
+"""Constants used throughout the PISA package.
+
+This module defines constants that are used across the PISA (Public Infrastructure Service Access) package to ensure 
+consistency and avoid duplication. These constants include valid modes of transportation, distance types, and 
+OpenStreetMap tags for facilities.
+
+Constants
+---------
+VALID_MODES_OF_TRANSPORT : set
+    Set of valid transportation modes that can be used in isopolygon calculations
+    
+VALID_DISTANCE_TYPES : set
+    Set of valid distance types (e.g., length or travel time) for isopolygon calculations
+    
+OSM_TAGS : dict
+    Dictionary of OpenStreetMap tags used to identify facilities of interest
+"""
 
 VALID_MODES_OF_TRANSPORT = {"driving", "walking", "cycling"}
 

--- a/pisa/facilities.py
+++ b/pisa/facilities.py
@@ -70,11 +70,11 @@ class Facilities:
     ----------
     admin_area_boundaries : Polygon or MultiPolygon
         The geographical boundaries of the administrative area for which to retrieve facilities
-    data_src : str, default="osm"
+    data_src : str, optional
         The data source from which to retrieve facility data. Currently supported:
-        - "osm": OpenStreetMap
-    osm_tags : dict, default=OSM_TAGS
-        Dictionary of OpenStreetMap tags to identify facilities of interest (e.g., {'amenity': 'hospital'})
+        - "osm": OpenStreetMap (default: "osm")
+    osm_tags : dict, optional
+        Dictionary of OpenStreetMap tags to identify facilities of interest (e.g., {'amenity': 'hospital'}). (default: OSM_TAGS)
         
     Notes
     -----

--- a/pisa/facilities.py
+++ b/pisa/facilities.py
@@ -1,3 +1,25 @@
+"""Facility data retrieval and management module for accessibility analysis.
+
+This module provides functionality for retrieving, managing, and analyzing facility location data
+within specified administrative areas. It supports extracting facility data from OpenStreetMap (OSM),
+generating potential facility locations through grid sampling, and preparing data for accessibility
+and optimization analyses.
+
+Classes
+-------
+Facilities : Main class for facility data retrieval and management
+
+The module enables users to work with both existing facilities (retrieved from OSM based on tags)
+and potential facility locations (generated through methodical sampling within administrative boundaries).
+It forms a core component in public infrastructure accessibility and location optimization workflows.
+
+See Also
+--------
+administrative_area : Module for retrieving administrative area boundaries
+population : Module for population data processing
+isopolygons : Module for calculating service areas around facilities
+"""
+
 import logging
 from dataclasses import dataclass, field
 

--- a/pisa/facilities.py
+++ b/pisa/facilities.py
@@ -37,6 +37,11 @@ class Facilities:
     The default OSM_TAGS are defined in the constants module and typically target health facilities. To use 
     different facility types, provide custom osm_tags when creating the Facilities object.
     
+    See Also
+    --------
+    AdministrativeArea : Class for retrieving administrative area boundaries
+    IsopolygonCalculator : Class for calculating service areas around facilities
+    
     Examples
     --------
     >>> from pisa.administrative_area import AdministrativeArea

--- a/pisa/facilities.py
+++ b/pisa/facilities.py
@@ -17,8 +17,39 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Facilities:
-    """Get existing and potential facility locations for given administrative area"""
-
+    """Retrieve and manage facility location data for a given administrative area.
+    
+    This class provides functionality to retrieve existing facilities within a specified administrative area from 
+    various data sources (currently supporting OpenStreetMap).
+    
+    Parameters
+    ----------
+    admin_area_boundaries : Polygon or MultiPolygon
+        The geographical boundaries of the administrative area for which to retrieve facilities
+    data_src : str, default="osm"
+        The data source from which to retrieve facility data. Currently supported:
+        - "osm": OpenStreetMap
+    osm_tags : dict, default=OSM_TAGS
+        Dictionary of OpenStreetMap tags to identify facilities of interest (e.g., {'amenity': 'hospital'})
+        
+    Notes
+    -----
+    The default OSM_TAGS are defined in the constants module and typically target health facilities. To use 
+    different facility types, provide custom osm_tags when creating the Facilities object.
+    
+    Examples
+    --------
+    >>> from pisa.administrative_area import AdministrativeArea
+    >>> from pisa.facilities import Facilities
+    >>> 
+    >>> # Get an administrative area for a specific country and region
+    >>> admin_area = AdministrativeArea("Timor-Leste", admin_level=1)
+    >>> boundaries = admin_area.get_admin_area_boundaries("Baucau")
+    >>> 
+    >>> # Get hospital facilities within the administrative area
+    >>> facilities = Facilities(admin_area_boundaries=boundaries)
+    >>> existing_facilities = facilities.get_existing_facilities()
+    """
     admin_area_boundaries: Polygon | MultiPolygon
     data_src: str = "osm"
     osm_tags: dict = field(
@@ -26,7 +57,29 @@ class Facilities:
     )
 
     def get_existing_facilities(self) -> DataFrame:
-        """Get facilities from specified data source"""
+        """Retrieve existing facilities from the specified data source.
+        
+        This method acts as a dispatcher that calls the appropriate data source-specific method based on the `data_src` 
+        attribute of the Facilities instance.
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame containing facilities information with columns:
+            - osmid (index): Facility identifier (e.g., OSM ID for OpenStreetMap data)
+            - longitude: Longitude coordinate of the facility
+            - latitude: Latitude coordinate of the facility
+            
+        Raises
+        ------
+        NotImplementedError
+            If the specified data source is not implemented
+            
+        Notes
+        -----
+        Currently, only the "osm" (OpenStreetMap) data source is implemented. To support additional data sources, 
+        implement new methods and update this dispatcher method accordingly, or refactor to use an abstract base class.
+        """
         if self.data_src == "osm":
             return self._get_existing_facilities_osm(
                 admin_area_boundaries=self.admin_area_boundaries, osm_tags=self.osm_tags
@@ -37,24 +90,30 @@ class Facilities:
     def _get_existing_facilities_osm(
         osm_tags: dict, admin_area_boundaries: Polygon | MultiPolygon
     ) -> DataFrame:
-        """
-        Fetches existing facilities from OpenStreetMap (OSM) within a specified administrative area.
+        """Fetch existing facilities from OpenStreetMap (OSM) within a specified administrative area.
+        
         Parameters
         ----------
         osm_tags : dict
             Dictionary of OSM tags to filter facilities (e.g., {'amenity': 'school'})
-        administrative_area : Polygon | MultiPolygon
-            Geographic area within which to search for facilities, defined as a shapely Polygon
-            or MultiPolygon object
+        admin_area_boundaries : Polygon or MultiPolygon
+            Geographic area within which to search for facilities, defined as a shapely Polygon or MultiPolygon object
+            
         Returns
         -------
         pandas.DataFrame
             DataFrame containing facilities information with columns:
             - osmid (index): OSM ID of the facility
-            - longitude: Longitude of facility
-            - latitude: Latitude of facility
+            - longitude: Longitude coordinate of the facility
+            - latitude: Latitude coordinate of the facility
+            
+        Notes
+        -----
+        This method uses the OSMnx library to retrieve facilities matching the specified tags from OpenStreetMap. If no 
+        facilities are found, it returns an empty DataFrame with the expected structure.
+        
+        In case of an InsufficientResponseError from the OSM API, an empty GeoDataFrame is created as a fallback.
         """
-
         logger.info(f"Retrieving existing facilities with tags {osm_tags} using OSM.")
 
         # retrieves facilities GeodataFrame from osm
@@ -88,16 +147,33 @@ class Facilities:
         ]
 
     def estimate_potential_facilities(self, spacing: float) -> gpd.GeoDataFrame:
-        """Create grid of potential facility locations
-
-        Create a grid of evenly spaced points within the given GeoDataFrame.
-
-        Arguments:
-            spacing: The distance between the points in coordinate units.
-
-        Returns:
-            GeoDataFrame containing potential facility locations
-
+        """Create a grid of potential facility locations within the administrative area.
+        
+        This method generates a regular grid of points within the administrative area boundaries that can be used as 
+        potential locations for new facilities in optimization scenarios.
+        
+        Parameters
+        ----------
+        spacing : float
+            The distance between adjacent points in the grid, in coordinate units (degrees). Smaller values create a 
+            denser grid with more potential facility locations.
+            
+        Returns
+        -------
+        geopandas.GeoDataFrame
+            DataFrame containing potential facility locations with columns:
+            - ID (index): Unique identifier for each potential facility location
+            - longitude: Longitude coordinate of the potential facility
+            - latitude: Latitude coordinate of the potential facility
+            
+        Notes
+        -----
+        The grid is created by:
+        1. Finding the bounding box of the administrative area
+        2. Creating a regular grid covering the entire bounding box
+        3. Clipping the grid to include only points within the actual administrative area boundaries
+        
+        The resulting grid points are spaced at regular intervals determined by the spacing parameter.
         """
         # Get the bounds of the polygon
         minx, miny, maxx, maxy = self.admin_area_boundaries.bounds

--- a/pisa/facilities.py
+++ b/pisa/facilities.py
@@ -13,6 +13,28 @@ The module enables users to work with both existing facilities (retrieved from O
 and potential facility locations (generated through methodical sampling within administrative boundaries).
 It forms a core component in public infrastructure accessibility and location optimization workflows.
 
+Examples
+--------
+Retrieve existing facilities and generate potential facility locations:
+
+>>> from pisa.administrative_area import AdministrativeArea
+>>> from pisa.facilities import Facilities
+>>>
+>>> # Get administrative area boundaries
+>>> admin_area = AdministrativeArea("Timor-Leste", admin_level=1)
+>>> boundaries = admin_area.get_admin_area_boundaries("Baucau")
+>>>
+>>> # Create a facilities object
+>>> facilities = Facilities(admin_area_boundaries=boundaries)
+>>>
+>>> # Get existing facilities from OpenStreetMap
+>>> existing = facilities.get_existing_facilities()
+>>> print(f"Found {len(existing)} existing facilities")
+>>>
+>>> # Generate potential facility locations (grid points)
+>>> potential = facilities.estimate_potential_facilities(spacing=0.05)
+>>> print(f"Generated {len(potential)} potential facility locations")
+
 See Also
 --------
 administrative_area : Module for retrieving administrative area boundaries

--- a/pisa/isopolygons.py
+++ b/pisa/isopolygons.py
@@ -28,7 +28,8 @@ from pandas import DataFrame
 from shapely import Polygon
 from shapely.geometry import shape
 
-from pisa.utils import disk_cache, validate_distance_type, validate_mode_of_transport
+from pisa.utils import (disk_cache, validate_distance_type,
+                        validate_mode_of_transport)
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +208,12 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         Buffer distance to apply around network nodes, default is 0.001
     edge_buffer : float, optional
         Buffer distance to apply around network edges, default is 0.0005
+        
+    See Also
+    --------
+    IsopolygonCalculator : Abstract base class
+    OsmIsopolygonCalculatorAlternative : Simplified OSM-based implementation
+    MapboxIsopolygonCalculator : Mapbox API-based implementation
     """
 
     def __init__(
@@ -448,6 +455,12 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
     buffer : float, optional
         Buffer distance in meters to apply around network skeletons (default: 50)
         
+    See Also
+    --------
+    IsopolygonCalculator : Abstract base class
+    OsmIsopolygonCalculator : OSM-based implementation with precise node/edge buffering
+    MapboxIsopolygonCalculator : Mapbox API-based implementation
+        
     Notes
     -----
     This implementation generally produces less accurate but smoother isopolygons
@@ -614,6 +627,12 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
         A valid Mapbox API access token with Isochrone API permissions
     base_url : str, optional
         The base URL for the Mapbox Isochrone API, default is 'https://api.mapbox.com/isochrone/v1/'
+        
+    See Also
+    --------
+    IsopolygonCalculator : Abstract base class
+    OsmIsopolygonCalculator : OSM-based implementation with precise node/edge buffering
+    OsmIsopolygonCalculatorAlternative : Simplified OSM-based implementation
         
     Notes
     -----

--- a/pisa/isopolygons.py
+++ b/pisa/isopolygons.py
@@ -1,13 +1,14 @@
 """
 This module provides functionality for calculating isopolygons around facilities using different methods and services.
 
-An isopolygon represents the area that can be reached within a specific distance (isodistance) or time (isochrone) from a facility.
+An isopolygon represents the area that can be reached within a specific distance (isodistance) or time (isochrone) from a
+ facility.
 
 The module contains an abstract base class IsopolygonCalculator and its implementations.
 
 Note:
-    To implement a new way of calculating isopolygons (e.g., using Google Maps),
-    create a class that inherits from IsopolygonCalculator and implements calculate_isopolygons.
+    To implement a new way of calculating isopolygons (e.g., using Google Maps), create a class that inherits from 
+    IsopolygonCalculator and implements calculate_isopolygons.
 
 """
 
@@ -51,8 +52,28 @@ class IsopolygonCalculator(ABC):
 
     @staticmethod
     def _validate_facilities_df_format(facilities_df: DataFrame) -> DataFrame:
-        """Checks that facilities_df has columns "longitude and latitude, and
-        has one or more rows"""
+        """Validate that facilities DataFrame has the required format.
+        
+        This validation ensures that the facilities DataFrame contains the minimum required information for isopolygon 
+        calculation: longitude and latitude coordinates for at least one facility.
+
+        Parameters
+        ----------
+        facilities_df : pandas.DataFrame
+            DataFrame containing facility locations to validate
+            
+        Returns
+        -------
+        pandas.DataFrame
+            The validated DataFrame (unchanged)
+            
+        Raises
+        ------
+        ValueError
+            If facilities_df is missing required columns 'longitude' and 'latitude'
+        ValueError
+            If facilities_df has no rows (empty DataFrame)
+        """
 
         if (
             "longitude" not in facilities_df.columns
@@ -67,22 +88,30 @@ class IsopolygonCalculator(ABC):
 
     @staticmethod
     def _validate_distance_values_are_ints(distance_values) -> list[int]:
-        """
-        Ensures that distance_values are in the correct format for calculating isopolygons.
-        It converts single integer inputs into a list format.
-
-        The requirement that all distance_values be integers comes from the Mapbox Isochrone API.
-
-        Args:
-            distance_values (int | list[int]): Either a single integer or a list of integers representing
-                distances for isopolygon calculations.
-        Returns:
-            list[int]: A list containing the validated distance values. If input was a single integer,
-                returns a single-element list.
-        Raises:
-            TypeError: If distance_values is neither an integer nor a list of integers.
-            TypeError: If any element in the distance_values list is not an integer.
-
+        """Ensure that distance values are integers and properly formatted as a list.
+        
+        Parameters
+        ----------
+        distance_values : int or list[int]
+            Either a single integer or a list of integers representing distances for isopolygon calculations
+            
+        Returns
+        -------
+        list[int]
+            A list containing the validated distance values. If input was a single integer, returns a single-element 
+            list.
+            
+        Raises
+        ------
+        TypeError
+            If distance_values is neither an integer nor a list of integers
+        TypeError
+            If any element in the distance_values list is not an integer
+            
+        Notes
+        -----
+        The requirement that all distance values be integers comes from the Mapbox Isochrone API,
+        but is applied to all implementations for consistency.
         """
 
         if isinstance(distance_values, int):
@@ -96,9 +125,25 @@ class IsopolygonCalculator(ABC):
         raise TypeError("distance_values must be a list of integers")
 
     def _validate_distance_upper_limits(self) -> None:
-        """Checks that distance_values are within the permitted limits:
-        100.000 meters for length and 60 minutes for time. This is requested by
-        the Mapbox Isochrone API.
+        """Validate that distance values are within permitted limits.
+        
+        This method checks that all distance values are within the API-imposed limits:
+        - For 'length' type: maximum of 100,000 meters
+        - For 'travel_time' type: maximum of 60 minutes
+        
+        Returns
+        -------
+        None
+        
+        Raises
+        ------
+        ValueError
+            If any distance value exceeds the maximum limit for its distance type
+            
+        Notes
+        -----
+        These limits are imposed by the Mapbox Isochrone API specifications. Even when using other providers (e.g., OSM),
+         the same limits are applied for consistency across implementations.
         """
 
         if self.distance_type == "length" and max(self.distance_values) > 100000:
@@ -113,12 +158,56 @@ class IsopolygonCalculator(ABC):
 
     @abstractmethod
     def calculate_isopolygons(self) -> DataFrame:
-        """Must be implemented in subclasses"""
+        """Calculate isopolygons for the specified facilities.
+        
+        This abstract method must be implemented by subclasses to provide the actual implementation of isopolygon 
+        calculation using specific data sources and algorithms.
+                    
+        Specific implementations should provide detailed error handling and logging appropriate to their data sources and
+         algorithms.
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame containing isopolygons with the following structure:
+            - Each row represents a facility from facilities_df
+            - One column named 'ID_{distance}' for each distance value in distance_values, where {distance} is the 
+            distance value in meters or minutes
+            - Each cell contains a Shapely Polygon or MultiPolygon representing the area that can be reached within the 
+            corresponding distance
+              
+        Raises
+        ------
+        NotImplementedError
+            If this method is not implemented by a subclass
+        """
         pass
 
 
 class OsmIsopolygonCalculator(IsopolygonCalculator):
-    """This implementation of IsopolygonCalculator uses OpenStreetMap data to calculate isopolygons."""
+    """OpenStreetMap-based implementation of isopolygon calculation.
+    
+    This implementation uses OpenStreetMap road network data to calculate isopolygons (isochrones or isodistances) 
+    around facilities. It leverages the NetworkX and OSMnx libraries for network analysis.
+    
+    This implementation performs network-based calculations on an OSM road network, which provides accurate results but 
+    may be computationally intensive for large areas or many facilities.
+
+    Parameters
+    ----------
+    facilities_df : pandas.DataFrame
+        DataFrame containing facility locations with 'longitude' and 'latitude' columns
+    distance_type : str
+        Type of distance to calculate ('length' or 'travel_time')
+    distance_values : list[int]
+        List of distance values in meters (for 'length') or minutes (for 'travel_time')
+    road_network : networkx.MultiDiGraph
+        Road network graph to use for calculations
+    node_buffer : float, optional
+        Buffer distance to apply around network nodes, default is 0.001
+    edge_buffer : float, optional
+        Buffer distance to apply around network edges, default is 0.0005
+    """
 
     def __init__(
         self,
@@ -160,13 +249,30 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         }
 
     def calculate_isopolygons(self) -> DataFrame:
-        """Calculates isopolygons for each facility at different distances (distance_values).
-
-        An isopolygon represents the area that can be reached within a specific distance/time from a facility
-        using the road network.
-
-        N.B.: distances will be computed with respect to the nearest node to the facility,
-        not the facility itself."""
+        """Calculate isopolygons for each facility at different distances.
+        
+        This method generates isopolygons (areas reachable within specific travel times or distances)
+        for each facility using the OpenStreetMap road network data.
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame containing isopolygons with the following structure:
+            - Each row represents a facility from facilities_df
+            - One column named 'ID_{distance}' for each distance value in distance_values,
+              where {distance} is the distance value in meters or minutes
+            - Each cell contains a Shapely Polygon or MultiPolygon representing
+              the area that can be reached within the corresponding distance
+              
+        Notes
+        -----
+        - Distances are computed with respect to the nearest node to the facility,
+          not the facility itself
+        - The method creates network "skeletons" and then buffers nodes and edges
+          separately with different buffer sizes to create accurate isopolygons
+        - This implementation provides more accurate isopolygons compared to the
+          alternative implementation but may be more computationally intensive
+        """
 
         # Initialize an empty DataFrame to store isopolygons
         index = self.nearest_nodes_dict.keys()
@@ -206,26 +312,41 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         node_buffer: float,
         edge_buffer: float,
     ) -> Polygon:
-        """The nodes and edges form the "skeleton" of the isopolygon. This function turns that skeleton into
-        a polygon by buffering and merging the geometries of the nodes and edges.
-
+        """Convert an isopolygon skeleton into a proper polygon by buffering.
+        
+        This method takes the "skeleton" of an isopolygon (nodes and edges from the road network) and turns it into a 
+        proper polygon by buffering and merging the geometries.
+        
+        Parameters
+        ----------
+        nodes_gdf : geopandas.GeoSeries
+            GeoSeries containing node geometries (points)
+        edges_gdf : geopandas.GeoSeries
+            GeoSeries containing edge geometries (lines)
+        node_buffer : float
+            Buffer distance to apply around nodes
+        edge_buffer : float
+            Buffer distance to apply around edges
+            
         Returns
         -------
         shapely.geometry.Polygon
             A polygon representing the merged buffer zones
+            
         Raises
         ------
         ValueError
             If edge_buffer is less than or equal to 0
         AttributeError
             If the unary_union results in two (or more) disconnected polygons
+            
         Notes
         -----
         - The function is sensitive to buffer size values. If they are too large relative to the distances between
-        nodes, the buffer could be so large that unintended areas are included by mistake (like nodes that had been
-        previously excluded).
-        - Input geometries should be in a projected CRS, not geographic CRS, to ensure
-          accurate buffer calculations."""
+          nodes, the buffer could be so large that unintended areas are included by mistake.
+        - Input geometries should be in a projected CRS, not geographic CRS, to ensure accurate buffer calculations.
+        - Node buffers create circles, while edge buffers create rounded rectangles along the edges
+        """
 
         if edge_buffer <= 0:
             raise ValueError("The parameter edge_buffer must be greater than 0.")
@@ -255,27 +376,37 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
         distance_value: int,
         distance_type: str,
     ) -> tuple[gpd.GeoSeries, gpd.GeoSeries]:
-        """Get nodes and edges within a specified distance from a certain node in a road network.
-        This will be the "skeleton" of the isopolygon.
-
-        Parameters:
-            road_network (nx.MultiDiGraph): The road network.
-            center_node (int): The node from which to measure the distance.
-            dist_value (int): The distance value.
-            distance_type (str): The type of distance (e.g., 'length').
-
-        Returns:
-            nodes_gdf: a GeoSeries of the nodes with their osmid and geometry.
-            edges_gdf: a GeoSeries of the geometry of the edges.
-
-
+        """Get nodes and edges within a specified distance from a center node.
+        
+        This method extracts all nodes and edges within a specified distance from a center node
+        in a road network, returning them as separate GeoSeries to form the "skeleton" of an isopolygon.
+        
+        Parameters
+        ----------
+        road_network : nx.MultiDiGraph
+            The road network graph
+        center_node : int
+            The node ID from which to measure distance
+        distance_value : int
+            The maximum distance value (in meters for 'length', minutes for 'travel_time')
+        distance_type : str
+            The type of distance to use ('length' or 'travel_time')
+            
+        Returns
+        -------
+        tuple[gpd.GeoSeries, gpd.GeoSeries]
+            A tuple containing:
+            - nodes_gdf: GeoSeries of node geometries
+            - edges_gdf: GeoSeries of edge geometries
+            
         Notes
         -----
-        If an edge (u,v) doesn't have geometry data in the road_network, edges_gdf contains
-        a straight line from u to v.
-
-        If no edges are found (for example, if all other nodes are too far away from center_node),
-        edges_gdf is an empty dataframe."""
+        - If an edge doesn't have geometry data in the road_network, a straight line
+          from the source to target node is used instead
+        - If no edges are found (e.g., if all other nodes are beyond the distance threshold),
+          edges_gdf will be an empty GeoSeries
+        - The method uses NetworkX's ego_graph to extract the subgraph within the specified distance
+        """
 
         subgraph = nx.ego_graph(
             road_network, center_node, radius=distance_value, distance=distance_type
@@ -297,7 +428,32 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
 
 
 class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
-    """This implementation of IsopolygonCalculator uses OpenStreetMap data to calculate isopolygons."""
+    """Alternative OpenStreetMap-based implementation of isopolygon calculation.
+    
+    This implementation uses OpenStreetMap road network data to calculate isopolygons
+    (isochrones or isodistances) around facilities. It takes a simpler approach
+    by buffering network skeletons rather than the more complex node and edge buffering
+    approach used by the OsmIsopolygonCalculator.
+    
+    Parameters
+    ----------
+    facilities_df : pandas.DataFrame
+        DataFrame containing facility locations with 'longitude' and 'latitude' columns
+    distance_type : str
+        Type of distance to calculate ('length' or 'travel_time')
+    distance_values : list[int]
+        List of distance values in meters (for 'length') or minutes (for 'travel_time')
+    road_network : networkx.MultiDiGraph
+        Road network graph to use for calculations
+    buffer : float, optional
+        Buffer distance in meters to apply around network skeletons (default: 50)
+        
+    Notes
+    -----
+    This implementation generally produces less accurate but smoother isopolygons
+    compared to the standard OsmIsopolygonCalculator. It may be more suitable for
+    visualization purposes or when computational efficiency is a priority.
+    """
 
     def __init__(
         self,
@@ -336,15 +492,28 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
         }
 
     def calculate_isopolygons(self) -> DataFrame:
-        """
-        Calculate isopolygons for each facility at different distances (distance_values).
-
-        An isopolygon represents the area that can be reached within a specific distance/time from a facility
-        using the road network.
-
-        N.B.: distances will be computed with respect to the nearest node to the facility,
-        not the facility itself.
-
+        """Calculate isopolygons for each facility at different distances.
+        
+        This method generates isopolygons (areas reachable within specific travel times or distances)
+        for each facility using the OpenStreetMap road network data.
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame containing isopolygons with the following structure:
+            - Each row represents a facility from facilities_df
+            - One column named 'ID_{distance}' for each distance value in distance_values,
+              where {distance} is the distance value in meters or minutes
+            - Each cell contains a Shapely Polygon or MultiPolygon representing
+              the area that can be reached within the corresponding distance
+              
+        Notes
+        -----
+        - Distances are computed with respect to the nearest node to the facility,
+          not the facility itself
+        - The method creates network "skeletons" (unions of node and edge geometries)
+          for each distance value, then buffers them to create isopolygons
+        - Computation time increases with the number of facilities and distance values
         """
 
         index = self.nearest_nodes_dict.keys()
@@ -378,18 +547,32 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
         distance_value: int,
         distance_type: str,
     ):
-        """
-        Get nodes and edges within distance_value from a node in the road network, and return
-        the union of their geometries. This will be the "skeleton" of the isopolygon.
-
-        Parameters:
-            road_network (nx.MultiDiGraph): The road network.
-            center_node (int): The node from which to measure the distance.
-            distance_value (int): The distance value.
-            distance_type (str): The type of distance (e.g., 'length').
-
-        Returns:
-            The union of the geometries of the nodes and edges within the specified distance from center_node.
+        """Get the skeleton of an isopolygon from a road network.
+        
+        This method extracts all nodes and edges within a specified distance from a center node
+        in a road network, and returns the union of their geometries as the "skeleton" of the isopolygon.
+        
+        Parameters
+        ----------
+        road_network : nx.MultiDiGraph
+            The road network graph
+        center_node : int
+            The node ID from which to measure distance
+        distance_value : int
+            The maximum distance value (in meters for 'length', minutes for 'travel_time')
+        distance_type : str
+            The type of distance to use ('length' or 'travel_time')
+            
+        Returns
+        -------
+        shapely.geometry
+            The union of geometries of all nodes and edges within the specified distance,
+            representing the "skeleton" of the isopolygon
+            
+        Notes
+        -----
+        If no edges are found (e.g., if all other nodes are beyond the distance threshold),
+        the method returns only the union of node geometries.
         """
         subgraph = nx.ego_graph(
             road_network, center_node, radius=distance_value, distance=distance_type
@@ -411,10 +594,35 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
 
 
 class MapboxIsopolygonCalculator(IsopolygonCalculator):
-    """From Mapbox docs: When you provide geographic coordinates to a Mapbox API,
+    """Mapbox-based implementation of isopolygon calculation.
+    
+    This implementation uses the Mapbox Isochrone API to calculate isopolygons
+    (isochrones or isodistances) around facilities.
+    
+    Parameters
+    ----------
+    facilities_df : pandas.DataFrame
+        DataFrame containing facility locations with 'longitude' and 'latitude' columns
+    distance_type : str
+        Type of distance to calculate ('length' or 'travel_time')
+    distance_values : list[int]
+        List of distance values in meters (for 'length') or minutes (for 'travel_time')
+        Maximum of 4 values allowed by the Mapbox API
+    mode_of_transport : str
+        The mode of transport to use (must be one of 'driving', 'walking', 'cycling')
+    mapbox_api_token : str
+        A valid Mapbox API access token with Isochrone API permissions
+    base_url : str, optional
+        The base URL for the Mapbox Isochrone API, default is 'https://api.mapbox.com/isochrone/v1/'
+        
+    Notes
+    -----
+    From Mapbox docs: When providing geographic coordinates to a Mapbox API,
     they should be formatted in the order longitude, latitude and specified as decimal degrees
     in the WGS84 coordinate system. This pattern matches existing standards, including GeoJSON and KML.
-    Mapbox APIs use GeoJSON formatting wherever possible to represent geospatial data.
+    
+    This implementation is subject to Mapbox API rate limits and requires a valid Mapbox account
+    and access token.
     """
 
     def __init__(
@@ -441,20 +649,27 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
         )
 
     def calculate_isopolygons(self) -> DataFrame:
-        """Calculates isopolygons for all facilities using Mapbox API.
-
-        This method generates isopolygons (polygons of equal distance/time) for each facility
-        using the Mapbox Isochrone API.
-
-        Returns:
-            Dataframe: A pandas DataFrame where:
-                - Each row represents a facility
-                - Each column represents a distance value prefixed with "ID_"
-                - Each cell contains the corresponding isopolygon geometry
-        Note:
-            - Requires valid Mapbox API credentials
-            - Subject to Mapbox API rate limits (300 requests per minute)
-            - Uses the distance values specified in self.distance_values
+        """Calculate isopolygons for all facilities using the Mapbox API.
+        
+        This method generates isopolygons (areas reachable within specific travel times or distances)
+        for each facility using the Mapbox Isochrone API.
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame containing isopolygons with the following structure:
+            - Each row represents a facility from facilities_df
+            - One column named 'ID_{distance}' for each distance value in distance_values,
+              where {distance} is the distance value in meters or minutes
+            - Each cell contains a Shapely Polygon or MultiPolygon representing
+              the area that can be reached within the corresponding distance
+              
+        Notes
+        -----
+        - Requires a valid Mapbox API token with appropriate permissions
+        - Subject to Mapbox API rate limits (300 requests per minute)
+        - Makes one API request per facility (not per distance value)
+        - The API returns GeoJSON features that are converted to Shapely geometries
         """
 
         columns = [f"ID_{d}" for d in self.distance_values]
@@ -481,7 +696,20 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
         return isopolygons
 
     def _build_request_url(self, longitude: float, latitude: float) -> str:
-        """Builds the Mapbox API request URL for isopolygon calculation."""
+        """Build the Mapbox API request URL for isopolygon calculation.
+        
+        Parameters
+        ----------
+        longitude : float
+            The longitude coordinate of the facility
+        latitude : float
+            The latitude coordinate of the facility
+            
+        Returns
+        -------
+        str
+            The complete URL for the Mapbox Isochrone API request
+        """
         return (
             f"{self.base_url}mapbox/{self.route_profile}/{longitude},"
             f"{latitude}?{self.contour_type}={','.join(map(str, self.distance_values))}"
@@ -489,7 +717,20 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
         )
 
     def _handle_rate_limit(self, request_count: int) -> None:
-        """Handles Mapbox API rate limiting, a maximum of 300 requests per minute."""
+        """Handle Mapbox API rate limiting.
+        
+        The Mapbox API has a rate limit of 300 requests per minute. This method pauses execution for 60 seconds when 
+        reaching this limit to avoid rate limit errors.
+        
+        Parameters
+        ----------
+        request_count : int
+            The current count of API requests that have been made
+            
+        Returns
+        -------
+        None
+        """
 
         if (request_count + 1) % 300 == 0:
             logger.info("Reached Mapbox API request limit. Waiting for 1 minute...")
@@ -498,21 +739,38 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
 
     @disk_cache("mapbox_cache")
     def _fetch_isopolygons(self, request_url: str) -> list:
-        """
-        Makes a GET request to the Mapbox Isochrone API endpoint and handles various potential errors.
-
-        Args:
-            request_url (str): The complete URL for the Mapbox Isochrone API request.
-
-        Returns:
-            list: GeoJSON Feature object.
-
-        Raises:
-            ValueError: If the Mapbox access token is invalid (401 error).
-            PermissionError: If the token lacks permission to access the resource (403 error).
-            requests.exceptions.HTTPError: For other HTTP-related errors.
-            TimeoutError: If the request times out (>60 seconds).
-            RuntimeError: For unexpected errors during the API request.
+        """Fetch isopolygon data from the Mapbox Isochrone API.
+        
+        This method makes a GET request to the Mapbox Isochrone API and handles various potential errors that might 
+        occur during the request.
+        
+        Parameters
+        ----------
+        request_url : str
+            The complete URL for the Mapbox Isochrone API request
+            
+        Returns
+        -------
+        list
+            List of GeoJSON Feature objects representing isopolygons
+            
+        Raises
+        ------
+        ValueError
+            If the Mapbox access token is invalid (HTTP 401 error)
+        PermissionError
+            If the token lacks permission to access the resource (HTTP 403 error)
+        requests.exceptions.HTTPError
+            For other HTTP-related errors
+        TimeoutError
+            If the request times out (>60 seconds)
+        RuntimeError
+            For unexpected errors during the API request
+            
+        Notes
+        -----
+        This method uses the disk_cache decorator to avoid making repeated requests for the same URL, which helps reduce
+         API usage and improves performance for repeated calculations.
         """
 
         try:
@@ -560,18 +818,25 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
 
     @staticmethod
     def _validate_mapbox_distance_values(distance_values: list[int]) -> list[int]:
-        """Checks if distance_values meet Mapbox API requirements:
-        a maximum of 4 values in increasing order.
+        """Validate distance values against Mapbox API requirements.
+        
+        The Mapbox Isochrone API accepts a maximum of 4 distinct contour values, which must be provided in ascending 
+        order. This method validates the input against these constraints and sorts the values.
 
-        Args:
-            distance_values (list[int]): List of integer distances to validate
-
-        Returns:
-            list[int]: Sorted list of distance values
-
-        Raises:
-            ValueError: If more than 4 distance values are provided
-
+        Parameters
+        ----------
+        distance_values : list[int]
+            List of integer distances to validate
+            
+        Returns
+        -------
+        list[int]
+            Sorted list of distance values in ascending order
+            
+        Raises
+        ------
+        ValueError
+            If more than 4 distance values are provided (Mapbox API limitation)
         """
 
         if len(distance_values) > 4:
@@ -583,6 +848,28 @@ class MapboxIsopolygonCalculator(IsopolygonCalculator):
 
     @staticmethod
     def _validate_mapbox_token_not_empty(mapbox_api_token: str) -> str:
+        """Validate that the Mapbox API token is not empty.
+        
+        Parameters
+        ----------
+        mapbox_api_token : str
+            The Mapbox API token to validate
+            
+        Returns
+        -------
+        str
+            The validated Mapbox API token (unchanged)
+            
+        Raises
+        ------
+        ValueError
+            If the Mapbox API token is empty
+            
+        Notes
+        -----
+        This simple validation ensures that an API token has been provided.
+        It does not verify that the token is valid or has the necessary permissions.
+        """
         if not mapbox_api_token:
             raise ValueError("Mapbox API token is required")
         return mapbox_api_token

--- a/pisa/isopolygons.py
+++ b/pisa/isopolygons.py
@@ -1,15 +1,60 @@
-"""
+"""Isopolygon calculation module for service area analysis.
+
 This module provides functionality for calculating isopolygons around facilities using different methods and services.
-
 An isopolygon represents the area that can be reached within a specific distance (isodistance) or time (isochrone) from a
- facility.
+facility.
 
-The module contains an abstract base class IsopolygonCalculator and its implementations.
+The module contains an abstract base class IsopolygonCalculator and its implementations for different calculation 
+methods.
+
+Classes
+-------
+IsopolygonCalculator : Abstract base class for isopolygon calculations
+OsmIsopolygonCalculator : Implementation using OpenStreetMap road networks
+OsmIsopolygonCalculatorAlternative : Simplified implementation using OpenStreetMap
+MapboxIsopolygonCalculator : Implementation using the Mapbox API
+
+Examples
+--------
+Calculate isochrones around facilities using OpenStreetMap:
+
+>>> from pisa.administrative_area import AdministrativeArea
+>>> from pisa.facilities import Facilities
+>>> from pisa.osm_road_network import OsmRoadNetwork
+>>> from pisa.isopolygons import OsmIsopolygonCalculator
+>>> 
+>>> # Get administrative area and facilities
+>>> admin_area = AdministrativeArea("Timor-Leste", admin_level=1)
+>>> boundaries = admin_area.get_admin_area_boundaries("Baucau")
+>>> facilities = Facilities(admin_area_boundaries=boundaries)
+>>> existing_facilities = facilities.get_existing_facilities()
+>>> 
+>>> # Create a road network for travel time calculations
+>>> road_network = OsmRoadNetwork(
+>>>     admin_area_boundaries=boundaries,
+>>>     mode_of_transport="walking",
+>>>     distance_type="travel_time"
+>>> )
+>>> graph = road_network.get_osm_road_network()
+>>> 
+>>> # Calculate isochrones (5, 10, 15 minutes walking)
+>>> isopolygon_calculator = OsmIsopolygonCalculator(
+>>>     facilities_df=existing_facilities,
+>>>     distance_type="travel_time",
+>>>     distance_values=[5, 10, 15],
+>>>     road_network=graph
+>>> )
+>>> isopolygons = isopolygon_calculator.calculate_isopolygons()
 
 Note:
     To implement a new way of calculating isopolygons (e.g., using Google Maps), create a class that inherits from 
     IsopolygonCalculator and implements calculate_isopolygons.
 
+See Also
+--------
+facilities : Module for retrieving facility locations
+osm_road_network : Module for retrieving and processing road networks
+population_served_by_isopolygons : Module for analyzing population coverage
 """
 
 import json

--- a/pisa/isopolygons.py
+++ b/pisa/isopolygons.py
@@ -250,9 +250,9 @@ class OsmIsopolygonCalculator(IsopolygonCalculator):
     road_network : networkx.MultiDiGraph
         Road network graph to use for calculations
     node_buffer : float, optional
-        Buffer distance to apply around network nodes, default is 0.001
+        Buffer distance to apply around network nodes. (default: 0.001)
     edge_buffer : float, optional
-        Buffer distance to apply around network edges, default is 0.0005
+        Buffer distance to apply around network edges. (default: 0.0005)
         
     See Also
     --------
@@ -498,7 +498,7 @@ class OsmIsopolygonCalculatorAlternative(IsopolygonCalculator):
     road_network : networkx.MultiDiGraph
         Road network graph to use for calculations
     buffer : float, optional
-        Buffer distance in meters to apply around network skeletons (default: 50)
+        Buffer distance in meters to apply around network skeletons. (default: 50)
         
     See Also
     --------

--- a/pisa/osm_road_network.py
+++ b/pisa/osm_road_network.py
@@ -50,7 +50,18 @@ class OsmRoadNetwork:
         )
 
     def get_osm_road_network(self) -> nx.MultiDiGraph:
-        """Returns the processed OSM road network."""
+        """Get the processed OpenStreetMap road network for the administrative area.
+        
+        This method retrieves the OSM road network for the specified administrative area and processes it according to 
+        the configured distance type. If the distance type is 'travel_time', travel times are added to the network edges.
+        
+        Returns
+        -------
+        nx.MultiDiGraph
+            NetworkX MultiDiGraph representing the road network with appropriate attributes:
+            - If distance_type is 'length', the graph has 'length' attributes on edges (in meters)
+            - If distance_type is 'travel_time', the graph has 'travel_time' attributes on edges (in minutes)
+        """
 
         road_network = self._download_osm_road_network()
 
@@ -60,13 +71,35 @@ class OsmRoadNetwork:
         return road_network
 
     def _download_osm_road_network(self) -> nx.MultiDiGraph:
-        """Download the OSM road network from OpenStreetMap for the specified administrative area."""
+        """Download the OSM road network from OpenStreetMap for the administrative area.
+        
+        Returns
+        -------
+        nx.MultiDiGraph
+            NetworkX MultiDiGraph representing the road network within the administrative area
+        """
 
         return ox.graph_from_polygon(polygon=self.admin_area_boundaries, network_type=self.network_type)
 
     @staticmethod
     def _set_network_type(mode_of_transport: str) -> str:
-        """Set valid network_type based on valid values for mode_of_transport"""
+        """Convert mode of transport to OSMnx network type.
+    
+        This method maps PISA's mode of transport terminology to the terminology used by the OSMnx library:
+        - 'driving' -> 'drive'
+        - 'walking' -> 'walk'
+        - 'cycling' -> 'bike'
+
+        Parameters
+        ----------
+        mode_of_transport : str
+            The mode of transport (must be one of 'driving', 'walking', or 'cycling')
+            
+        Returns
+        -------
+        str
+            The corresponding OSMnx network type ('drive', 'walk', or 'bike')
+        """
 
         # validate mode of transport
         mode_of_transport = validate_mode_of_transport(mode_of_transport)
@@ -81,7 +114,23 @@ class OsmRoadNetwork:
 
     @staticmethod
     def _add_time_to_edges(road_network: nx.MultiDiGraph, fallback_speed: int | float | None) -> nx.MultiDiGraph:
-        """Add travel time edge attribute and change unit to minutes"""
+        """Add travel time attributes to the road network edges and convert to minutes.
+
+        Parameters
+        ----------
+        road_network : nx.MultiDiGraph
+            The road network graph to which travel times will be added
+        fallback_speed : int, float, or None
+            The default speed (in km/h) to use when speed limits are not available. If None, OSMnx's default values will
+             be used
+            
+        Returns
+        -------
+        nx.MultiDiGraph
+            The road network with travel times added to edges:
+            - Edge attribute 'speed_kph' contains the speed in kilometers per hour
+            - Edge attribute 'travel_time' contains the travel time in minutes
+        """
         road_network = ox.add_edge_speeds(road_network, fallback=fallback_speed)
         road_network = ox.add_edge_travel_times(road_network)
 

--- a/pisa/osm_road_network.py
+++ b/pisa/osm_road_network.py
@@ -11,6 +11,31 @@ OsmRoadNetwork : Class for retrieving and processing OSM road network data
 The module supports multiple transport modes, different distance types (length or travel time),
 and includes methods for validating inputs and handling missing speed data in OSM.
 
+Examples
+--------
+Retrieve and process a road network for walking travel time analysis:
+
+>>> from pisa.administrative_area import AdministrativeArea
+>>> from pisa.osm_road_network import OsmRoadNetwork
+>>>
+>>> # Get administrative area boundaries
+>>> admin_area = AdministrativeArea("Timor-Leste", admin_level=1)
+>>> boundaries = admin_area.get_admin_area_boundaries("Baucau")
+>>>
+>>> # Create a road network for walking travel time analysis
+>>> road_network = OsmRoadNetwork(
+>>>     admin_area_boundaries=boundaries,
+>>>     mode_of_transport="walking",
+>>>     distance_type="travel_time"
+>>> )
+>>>
+>>> # Get the processed network with travel time attributes
+>>> graph = road_network.get_osm_road_network()
+>>>
+>>> # Check some network statistics
+>>> print(f"Number of nodes: {len(graph.nodes)}")
+>>> print(f"Number of edges: {len(graph.edges)}")
+
 See Also
 --------
 isopolygons : Module for calculating service areas using road networks

--- a/pisa/osm_road_network.py
+++ b/pisa/osm_road_network.py
@@ -48,7 +48,6 @@ class OsmRoadNetwork:
         The speed to be used for road types where OSM does not provide a speed attribute.
         If not provided, osmnx will do the imputation (recommended).
     """
-
     def __init__(
         self,
         admin_area_boundaries: Polygon | MultiPolygon,
@@ -82,7 +81,6 @@ class OsmRoadNetwork:
             - If distance_type is 'length', the graph has 'length' attributes on edges (in meters)
             - If distance_type is 'travel_time', the graph has 'travel_time' attributes on edges (in minutes)
         """
-
         road_network = self._download_osm_road_network()
 
         if self.distance_type == "travel_time":
@@ -98,7 +96,6 @@ class OsmRoadNetwork:
         nx.MultiDiGraph
             NetworkX MultiDiGraph representing the road network within the administrative area
         """
-
         return ox.graph_from_polygon(polygon=self.admin_area_boundaries, network_type=self.network_type)
 
     @staticmethod
@@ -120,7 +117,6 @@ class OsmRoadNetwork:
         str
             The corresponding OSMnx network type ('drive', 'walk', or 'bike')
         """
-
         # validate mode of transport
         mode_of_transport = validate_mode_of_transport(mode_of_transport)
 

--- a/pisa/osm_road_network.py
+++ b/pisa/osm_road_network.py
@@ -1,10 +1,30 @@
+"""OpenStreetMap road network data retrieval and processing module.
+
+This module provides functionality for accessing and processing road network data from OpenStreetMap (OSM)
+for various transportation modes (driving, walking, cycling). It serves as the foundation for service area
+calculations and travel time/distance analyses in the PISA package.
+
+Classes
+-------
+OsmRoadNetwork : Class for retrieving and processing OSM road network data
+
+The module supports multiple transport modes, different distance types (length or travel time),
+and includes methods for validating inputs and handling missing speed data in OSM.
+
+See Also
+--------
+isopolygons : Module for calculating service areas using road networks
+administrative_area : Module for defining the geographic scope of the road network
+"""
+
 import logging
 
 import networkx as nx
 import osmnx as ox
 from shapely import MultiPolygon, Polygon
 
-from pisa.utils import validate_distance_type, validate_fallback_speed, validate_mode_of_transport
+from pisa.utils import (validate_distance_type, validate_fallback_speed,
+                        validate_mode_of_transport)
 
 logger = logging.getLogger(__name__)
 

--- a/pisa/population.py
+++ b/pisa/population.py
@@ -13,6 +13,28 @@ WorldpopPopulation : Implementation for WorldPop population data
 The module supports retrieving population data within specified administrative boundaries, aggregating the data at
 different resolutions, and preparing it for accessibility analysis with facilities.
 
+Examples
+--------
+Retrieve and process population data from WorldPop:
+
+>>> from pisa.administrative_area import AdministrativeArea
+>>> from pisa.population import WorldpopPopulation
+>>>
+>>> # Get administrative area boundaries
+>>> admin_area = AdministrativeArea("Timor-Leste", admin_level=1)
+>>> boundaries = admin_area.get_admin_area_boundaries("Baucau")
+>>> country_code = admin_area.get_iso3_country_code()
+>>>
+>>> # Create a population object and retrieve data
+>>> population = WorldpopPopulation(
+>>>     admin_area_boundaries=boundaries,
+>>>     iso3_country_code=country_code
+>>> )
+>>>
+>>> # Get processed population data as a GeoDataFrame
+>>> population_gdf = population.get_population_gdf()
+>>> print(f"Total population: {population_gdf['population'].sum()}")
+
 See Also
 --------
 administrative_area : Module for retrieving administrative area boundaries

--- a/pisa/population.py
+++ b/pisa/population.py
@@ -1,3 +1,24 @@
+"""Population data retrieval and processing module for geographic analysis.
+
+This module provides classes and functions for retrieving, processing, and analyzing population data from various 
+sources such as Facebook's Data for Good and WorldPop. It includes an abstract base class that defines the common 
+interface, and concrete implementations for specific data sources.
+
+Classes
+-------
+Population : Abstract base class for population data retrieval
+FacebookPopulation : Implementation for Facebook's High Resolution Population Density Maps
+WorldpopPopulation : Implementation for WorldPop population data
+
+The module supports retrieving population data within specified administrative boundaries, aggregating the data at
+different resolutions, and preparing it for accessibility analysis with facilities.
+
+See Also
+--------
+administrative_area : Module for retrieving administrative area boundaries
+facilities : Module for working with facility location data
+"""
+
 import urllib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass

--- a/pisa/population.py
+++ b/pisa/population.py
@@ -15,8 +15,20 @@ from shapely import MultiPolygon, Polygon
 
 @dataclass
 class Population(ABC):
-    """Abstract base class for Population. Subclasses must implement the method get_population_data()
-    If you want to add new data source (e.g. geojson): create new subclass with method get_population_data().
+    """Abstract base class for Population data retrieval and processing.
+    
+    This class provides the core functionality for retrieving and processing population data for a specified 
+    administrative area. Subclasses must implement the method get_population_data() to support different data sources.
+    
+    Parameters
+    ----------
+    admin_area_boundaries : Polygon or MultiPolygon
+        The geographical boundaries of the administrative area for which to retrieve population data
+    iso3_country_code : str
+        The ISO3 country code for the administrative area (e.g., 'TLS' for Timor-Leste)
+    population_resolution : int, optional
+        The decimal precision to which latitude and longitude coordinates are rounded for aggregation purposes 
+        (default: 5)
     """
 
     admin_area_boundaries: Polygon | MultiPolygon
@@ -24,8 +36,22 @@ class Population(ABC):
     population_resolution: int = 5
 
     def get_population_gdf(self) -> GeoDataFrame:
-        """Integrates the methods to get the population numbers for the selected area into one flow and
-        returns grouped population data for the admin area as a GeoDataFrame."""
+        """Get aggregated population data for the administrative area as a GeoDataFrame.
+        
+        This method integrates the population data retrieval workflow by:
+        1. Retrieving raw population data using the specific implementation of the get_population_data() method
+        2. Aggregating the population data based on the specified resolution
+        
+        Returns
+        -------
+        GeoDataFrame
+            Aggregated population data with columns:
+            - longitude: Rounded longitude coordinate
+            - latitude: Rounded latitude coordinate
+            - population: Total population at the coordinate
+            - geometry: Point geometry representing the coordinate
+            - ID: Unique identifier for each point
+        """
         population_df = self._get_population_df()
         return self._group_population(population_df, self.population_resolution)
 
@@ -33,10 +59,37 @@ class Population(ABC):
     def _group_population(
         population_df: pd.DataFrame, population_resolution: int
     ) -> GeoDataFrame:
-        """Group population data by longitude and latitude based on the population resolution. The population resolution
-        is an integer that indicates the number of digits after the decimal point to which latitude and longitude get rounded
-        and then grouped. The population of all rows with the same unique combination of latitude and longitude after
-        rounding by population resolution is summed. The resulting dataframe is returned as a GeoDataFrame.
+        """Group population data by coordinates based on a specified resolution.
+        
+        This method aggregates population data by rounding longitude and latitude coordinates to a specified decimal 
+        precision (population_resolution), then grouping by these rounded coordinates. For each unique coordinate pair,
+        the population values are summed.
+        
+        Parameters
+        ----------
+        population_df : pd.DataFrame
+            DataFrame containing population data with at least the columns:
+            - longitude: Longitude coordinate
+            - latitude: Latitude coordinate
+            - population: Population count
+            
+        population_resolution : int
+            Number of decimal places to round the coordinates to
+            
+        Returns
+        -------
+        GeoDataFrame
+            Aggregated population data with columns:
+            - longitude: Rounded longitude coordinate
+            - latitude: Rounded latitude coordinate
+            - population: Total population for the coordinate
+            - geometry: Point geometry created from the coordinates
+            - ID: Unique identifier for each point
+        
+        Notes
+        -----
+        This method creates point geometries using the rounded coordinates and assigns a unique ID to each point based 
+        on its position in the dataframe.
         """
         population_df.loc[:, ["longitude", "latitude"]] = population_df[
             ["longitude", "latitude"]
@@ -58,15 +111,55 @@ class Population(ABC):
 
     @abstractmethod
     def _get_population_df(self) -> pd.DataFrame:
-        """Must be implemented in subclasses"""
+        """Get population data from a specific data source.
+        
+        This abstract method must be implemented by subclasses to provide population data retrieval from specific sources
+         (e.g., Facebook, WorldPop).
+        
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame containing population data with columns:
+            - longitude: Longitude coordinate
+            - latitude: Latitude coordinate
+            - population: Population count at the coordinate
+            
+        Raises
+        ------
+        NotImplementedError
+            If this method is not implemented by a subclass
+        """
         pass
 
 
 class FacebookPopulation(Population):
+    """Population data from Facebook's High Resolution Population Density Maps.
+    
+    This class retrieves and processes population data from Facebook's Data for Good program, which provides 
+    high-resolution population density maps. The data is accessed via the Humanitarian Data Exchange (HDX) platform.
+    
+    The class follows the same initialization pattern as its parent class Population.
+    
+    See Also
+    --------
+    Population : Parent abstract class
+    WorldPopulation : Alternative population data source implementation
+    """
 
     def _get_population_df(self) -> pd.DataFrame:
-        """Download & process data from the chosen datasource 'facebook'. Returns a DataFrame with population data."""
-
+        """Download and process population data from Facebook.
+        
+        Implements the abstract method from the Population class to retrieve population data specifically from Facebook's
+         High Resolution Population Density Maps via the HDX platform.
+        
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with population data containing columns:
+            - longitude: Longitude coordinate
+            - latitude: Latitude coordinate
+            - population: Population count at the coordinate
+        """
         downloaded_data = self.download_population_facebook(
             iso3_country_code=self.iso3_country_code,
         )
@@ -81,7 +174,30 @@ class FacebookPopulation(Population):
 
     @staticmethod
     def download_population_facebook(iso3_country_code: str) -> pd.DataFrame:
-        """Download population data from 2020 from facebook for a country defined by the iso3_country_code."""
+        """Download Facebook population data for a specific country.
+        
+        This method retrieves population data from Facebook's High Resolution Population Density Maps via the 
+        Humanitarian Data Exchange (HDX) platform for a country specified by its ISO3 code.
+        
+        Parameters
+        ----------
+        iso3_country_code : str
+            The ISO3 country code for which to download population data (e.g., 'TLS' for Timor-Leste)
+        
+        Returns
+        -------
+        pd.DataFrame
+            Raw population data from Facebook for the specified country
+            
+        Raises
+        ------
+        Exception
+            If there are issues with the HDX configuration or data download
+            
+        Notes
+        -----
+        The method accesses the Facebook population dataset from the year 2020.
+        """
         try:
             Configuration.create(
                 hdx_site="prod", user_agent="Get_Population_Data", hdx_read_only=True
@@ -107,8 +223,28 @@ class FacebookPopulation(Population):
         iso3_country_code: str,
         admin_area_boundaries: Polygon | MultiPolygon,
     ) -> pd.DataFrame:
-        """Create geodataframe, clip with admin area boundaries to keep only those areas inside the admin area boundaries
-        and convert back to pandas dataframe"""
+        """Process Facebook population data for a specific administrative area.
+        
+        This method transforms raw Facebook population data into a filtered dataset that only includes points within the 
+        specified administrative area boundaries.
+        
+        Parameters
+        ----------
+        downloaded_data : pd.DataFrame
+            Raw population data downloaded from Facebook/HDX
+        iso3_country_code : str
+            ISO3 country code used to identify the population column in the data
+        admin_area_boundaries : Polygon or MultiPolygon
+            The geographical boundaries used to clip the population data
+            
+        Returns
+        -------
+        pd.DataFrame
+            Processed population data containing only points within the administrative area, with columns:
+            - longitude: Longitude coordinate
+            - latitude: Latitude coordinate
+            - population: Population count (renamed from country-specific column)
+        """
         gdf = GeoDataFrame(
             downloaded_data,
             geometry=points_from_xy(
@@ -123,10 +259,33 @@ class FacebookPopulation(Population):
 
 
 class WorldpopPopulation(Population):
+    """Population data from WorldPop global population data.
+    
+    This class retrieves and processes population data from the WorldPop project, which provides high-resolution 
+    population density estimates globally. The data is accessed via the WorldPop REST API.
+    
+    The class follows the same initialization pattern as its parent class Population.
+    
+    See Also
+    --------
+    Population : Parent abstract class
+    FacebookPopulation : Alternative population data source implementation
+    """
 
     def _get_population_df(self) -> pd.DataFrame:
-        """Download & process data from the chosen datasource 'worldpop'. Returns a DataFrame with population data."""
-
+        """Download and process population data from WorldPop.
+        
+        Implements the abstract method from the Population class to retrieve population data specifically from WorldPop's
+         REST API.
+        
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with population data containing columns:
+            - longitude: Longitude coordinate
+            - latitude: Latitude coordinate
+            - population: Population count at the coordinate
+        """
         downloaded_data = self.download_population_worldpop(
             iso3_country_code=self.iso3_country_code,
         )
@@ -140,8 +299,26 @@ class WorldpopPopulation(Population):
 
     @staticmethod
     def download_population_worldpop(iso3_country_code: str) -> str:
-        """Download population numbers from worldpop from last year for a country defined by the iso3_country_code."""
-
+        """Download population data from WorldPop for a specific country.
+        
+        This method retrieves population data from the WorldPop REST API for a country specified by its ISO3 code, using 
+        the most recently available dataset.
+        
+        Parameters
+        ----------
+        iso3_country_code : str
+            The ISO3 country code for which to download population data (e.g., 'TLS' for Timor-Leste)
+        
+        Returns
+        -------
+        str
+            File path to the downloaded raster data file
+            
+        Raises
+        ------
+        requests.exceptions.RequestException
+            If there are issues with the WorldPop API request
+        """
         worldpop_url = f"https://www.worldpop.org/rest/data/pop/wpgpunadj/?iso3={iso3_country_code}"
         headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
@@ -161,17 +338,26 @@ class WorldpopPopulation(Population):
     def process_population_worldpop(
         file_path: str, admin_area_boundaries: Polygon | MultiPolygon
     ) -> pd.DataFrame:
+        """Process WorldPop raster data for a specific administrative area.
+        
+        This method converts the downloaded WorldPop raster data into a DataFrame of point-based population values, 
+        filtered to include only points within the specified administrative area boundaries.
+        
+        Parameters
+        ----------
+        file_path : str
+            Path to the downloaded WorldPop raster file
+        admin_area_boundaries : Polygon or MultiPolygon
+            The geographical boundaries used to filter the population data
+            
+        Returns
+        -------
+        pd.DataFrame
+            Processed population data containing only points within the administrative area, with columns:
+            - longitude: Longitude coordinate
+            - latitude: Latitude coordinate
+            - population: Population count
         """
-        Processes the downloaded worldpop data raster file into the required format of a dataframe of longitude, latitude
-        and statistical population count
-
-        Function takes the bounds of the raster file in the raster_fpath, draws an evenly spaced sequence of points between
-        the xmin & xmax, and between ymin & ymax, and then generates a grid to cover the complete square area inside the
-        boundaries. The population count for each point in the grid that falls within the given MultiPolygon area
-        (identified by the mask) is extracted from the raster file, and a dataframe with latitude, longitude & population
-        count for each point in the raster is returned.
-        """
-
         # Convert raster file to dataframe
         with rasterio.open(file_path) as src:
             # Create 2D arrays
@@ -197,11 +383,31 @@ class WorldpopPopulation(Population):
     def get_admarea_mask(
         vector_polygon: Polygon | MultiPolygon, raster_layer: rasterio.DatasetReader
     ) -> np.ndarray:
-        """
-        Extract mask from raster for a given MultiPolygon
-
-        Return a boolean mask for the raster layer which is True where the (multi)polygon is located and false for all
-        points outside the given (Multi)Polygon
+        """Create a boolean mask identifying raster pixels within a vector polygon.
+        
+        This method creates a mask that can be used to filter raster data to include only points that fall within a 
+        specified vector polygon.
+        
+        Parameters
+        ----------
+        vector_polygon : Polygon or MultiPolygon
+            The vector geometry used to create the mask
+        raster_layer : rasterio.DatasetReader
+            The open raster dataset to be masked
+            
+        Returns
+        -------
+        np.ndarray
+            A boolean mask with the same dimensions as the raster, where:
+            - True: pixel is within the polygon
+            - False: pixel is outside the polygon
+            
+        Notes
+        -----
+        The method uses rasterio's mask function with the all_touched=True parameter,
+        which includes all pixels that are touched by the polygon, not just those
+        whose centers are within it. It then creates a boolean mask by checking
+        which pixels have values greater than zero.
         """
         gtraster, bound = mask(
             raster_layer, [vector_polygon], all_touched=True, crop=False

--- a/pisa/population_served_by_isopolygons.py
+++ b/pisa/population_served_by_isopolygons.py
@@ -124,12 +124,12 @@ def get_population_served_by_isopolygons(
     )
 
     # Clean up lists: replace [nan] and nan with [] and convert float lists to int lists
-    def sanitize_lists(x):
+    def sanitize_lists(x: list | float | int) -> list:
         """Convert list of floats to list of integers, or handle NaN values.
         
         Parameters
         ----------
-        x : list or scalar
+        x : list, float or int
             Input data that may be a list of population indices (as floats) or a scalar value
             
         Returns

--- a/pisa/utils.py
+++ b/pisa/utils.py
@@ -38,8 +38,8 @@ def disk_cache(cache_dir="cache"):
     
     Parameters
     ----------
-    cache_dir : str, default="cache"
-        Directory where cache files will be stored
+    cache_dir : str, optional
+        Directory where cache files will be stored. (default: "cache")
     
     Returns
     -------

--- a/pisa/utils.py
+++ b/pisa/utils.py
@@ -24,13 +24,14 @@ import logging
 import os
 import pickle
 from functools import wraps
+from typing import Callable
 
 from pisa.constants import VALID_DISTANCE_TYPES, VALID_MODES_OF_TRANSPORT
 
 logger = logging.getLogger(__name__)
 
 
-def disk_cache(cache_dir="cache"):
+def disk_cache(cache_dir: str = "cache") -> Callable:
     """Implement disk-based caching for function results.
     
     This decorator saves the result of a function call to a file on disk and loads it
@@ -69,7 +70,7 @@ def disk_cache(cache_dir="cache"):
         If there are issues with file operations
     """
 
-    def decorator(func):
+    def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args, **kwargs):
             # Ensure the cache directory exists

--- a/pisa/utils.py
+++ b/pisa/utils.py
@@ -10,28 +10,42 @@ logger = logging.getLogger(__name__)
 
 
 def disk_cache(cache_dir="cache"):
-    """
-    A decorator that implements disk-based caching for function results.
+    """Implement disk-based caching for function results.
+    
     This decorator saves the result of a function call to a file on disk and loads it
     on subsequent calls with the same arguments, avoiding redundant computations.
-    Args:
-        cache_dir (str, optional): Directory where cache files will be stored. Defaults to "cache".
-    Returns:
-        callable: A decorated function that implements caching behavior.
-    Example:
-        @disk_cache()
-        def expensive_computation(x):
-            # Some time-consuming calculation
-            return x ** 2
-    Notes:
-        - Cache files are stored as pickle files
-        - Cache keys are generated using SHA-256 hash of function name and arguments
-        - Logs cache hits/misses using the logging module
-        - Creates cache directory if it doesn't exist
-        - Cache files are named using the hash of the function name and arguments
-    Raises:
-        pickle.PickleError: If there are issues serializing/deserializing the cached data
-        OSError: If there are issues with file operations
+    
+    Parameters
+    ----------
+    cache_dir : str, default="cache"
+        Directory where cache files will be stored
+    
+    Returns
+    -------
+    callable
+        A decorated function that implements caching behavior
+    
+    Example
+    -------
+    >>> @disk_cache()
+    >>> def expensive_computation(x):
+    >>>     # Some time-consuming calculation
+    >>>     return x ** 2
+    
+    Notes
+    -----
+    - Cache files are stored as pickle files
+    - Cache keys are generated using SHA-256 hash of function name and arguments
+    - Logs cache hits/misses using the logging module
+    - Creates cache directory if it doesn't exist
+    - Cache files are named using the hash of the function name and arguments
+    
+    Raises
+    ------
+    pickle.PickleError
+        If there are issues serializing/deserializing the cached data
+    OSError
+        If there are issues with file operations
     """
 
     def decorator(func):
@@ -72,6 +86,27 @@ def disk_cache(cache_dir="cache"):
 
 
 def validate_distance_type(distance_type: str) -> str:
+    """Validate and normalize distance type input.
+    
+    Parameters
+    ----------
+    distance_type : str
+        The distance type to validate ("length" or "travel_time")
+        
+    Returns
+    -------
+    str
+        Normalized distance type (lowercase, stripped of whitespace)
+        
+    Raises
+    ------
+    ValueError
+        If distance_type is not one of the valid types defined in VALID_DISTANCE_TYPES
+    
+    See Also
+    --------
+    VALID_DISTANCE_TYPES : Set of valid distance types
+    """
     distance_type = distance_type.lower().strip()
 
     if distance_type not in VALID_DISTANCE_TYPES:
@@ -80,6 +115,32 @@ def validate_distance_type(distance_type: str) -> str:
 
 
 def validate_mode_of_transport(mode_of_transport: str) -> str:
+    """Validate and normalize mode of transport input.
+    
+    Parameters
+    ----------
+    mode_of_transport : str
+        The mode of transport to validate (e.g., "driving", "walking", "cycling")
+        
+    Returns
+    -------
+    str
+        Normalized mode of transport (lowercase, stripped of whitespace)
+        
+    Raises
+    ------
+    ValueError
+        If mode_of_transport is not one of the valid modes defined in VALID_MODES_OF_TRANSPORT
+        
+    Notes
+    -----
+    This function normalizes the input by converting to lowercase and removing
+    leading/trailing whitespace before validation.
+    
+    See Also
+    --------
+    VALID_MODES_OF_TRANSPORT : Set of valid transport modes
+    """
     mode_of_transport = mode_of_transport.lower().strip()
 
     if mode_of_transport not in VALID_MODES_OF_TRANSPORT:
@@ -90,9 +151,37 @@ def validate_mode_of_transport(mode_of_transport: str) -> str:
 def validate_fallback_speed(
     fallback_speed: int | float | None, network_type: str
 ) -> int | float | None:
-    """
-    If no custom fallback speed is provided, return None. Else, validate that the
-    user-provided fallback speed is within reasonable bounds for the given mode of transport.
+    """Validate that a fallback speed is within reasonable bounds for the given transport mode.
+    
+    Parameters
+    ----------
+    fallback_speed : int, float, or None
+        The fallback speed to validate, in kilometers per hour.
+        If None, no validation is performed.
+    network_type : str
+        The network type/mode of transport ("drive", "walk", "bike")
+        
+    Returns
+    -------
+    int, float, or None
+        The validated fallback speed or None if no fallback speed was provided
+        
+    Raises
+    ------
+    ValueError
+        If fallback_speed is not a number
+    ValueError
+        If fallback_speed is not positive
+    ValueError
+        If fallback_speed exceeds reasonable bounds for the given mode of transport:
+        - For walking: speed must be <= 7 km/h
+        - For cycling: speed must be <= 25 km/h
+        - For driving: speed must be <= 130 km/h
+        
+    Notes
+    -----
+    This function is used to ensure that fallback speeds (used when OSM data doesn't
+    provide speed information) are within reasonable bounds for the mode of transport.
     """
 
     if fallback_speed is not None:

--- a/pisa/utils.py
+++ b/pisa/utils.py
@@ -1,3 +1,24 @@
+"""Utility functions and helpers for the PISA package.
+
+This module contains utility functions that are used throughout the PISA package, including
+validation functions, caching mechanisms, and other helper functions that support the core
+functionality of the package.
+
+Functions
+---------
+disk_cache : Decorator for disk-based caching of function results
+validate_mode_of_transport : Validate that a mode of transport is supported
+validate_distance_type : Validate that a distance type is supported
+validate_fallback_speed : Validate and process fallback speed values
+
+The utilities in this module help ensure consistent validation of inputs, efficient computation
+through caching, and other common operations needed throughout the package.
+
+See Also
+--------
+constants : Module containing constants used by these utility functions
+"""
+
 import hashlib
 import logging
 import os

--- a/pisa/visualisation.py
+++ b/pisa/visualisation.py
@@ -15,6 +15,35 @@ plot_population_heatmap : Create a heatmap showing population density
 The visualizations use Folium (based on Leaflet.js) to create interactive web maps that can be
 displayed in notebooks, web applications, or exported as HTML files.
 
+Examples
+--------
+Create interactive maps for facilities and population:
+
+>>> from pisa.administrative_area import AdministrativeArea
+>>> from pisa.facilities import Facilities
+>>> from pisa.population import WorldpopPopulation
+>>> from pisa.visualisation import plot_facilities, plot_population
+>>>
+>>> # Get administrative area and data
+>>> admin_area = AdministrativeArea("Timor-Leste", admin_level=1)
+>>> boundaries = admin_area.get_admin_area_boundaries("Baucau")
+>>> country_code = admin_area.get_iso3_country_code()
+>>>
+>>> # Get facilities data
+>>> facilities = Facilities(admin_area_boundaries=boundaries)
+>>> existing_facilities = facilities.get_existing_facilities()
+>>>
+>>> # Get population data
+>>> population = WorldpopPopulation(
+>>>     admin_area_boundaries=boundaries,
+>>>     iso3_country_code=country_code
+>>> )
+>>> population_gdf = population.get_population_gdf()
+>>>
+>>> # Create interactive maps
+>>> facility_map = plot_facilities(existing_facilities, boundaries)
+>>> population_map = plot_population(population_gdf, boundaries)
+
 See Also
 --------
 facilities : Module for facility data processing

--- a/pisa/visualisation.py
+++ b/pisa/visualisation.py
@@ -100,7 +100,7 @@ def plot_facilities(
     folium_map = folium.Map(location=start_coords, tiles=tiles)
 
     # Add a polygon layer for the administrative area boundaries
-    def style_function(x):
+    def style_function(x) -> dict:
         return {
             "fillColor": "green",
             "color": "green",
@@ -247,7 +247,11 @@ def plot_population(
     return folium_map
 
 
-def plot_isochrones(df_isopolygons: pd.DataFrame, admin_area_boundaries: MultiPolygon | Polygon, tiles="OpenStreetMap"):
+def plot_isochrones(
+    df_isopolygons: pd.DataFrame,
+    admin_area_boundaries: MultiPolygon | Polygon,
+    tiles: str = "OpenStreetMap",
+) -> folium.Map:
     """Plot isochrones/isopolygons for multiple facilities on an interactive map.
     
     This function creates a Folium map displaying isopolygons (areas reachable within specific travel times or distances)

--- a/pisa/visualisation.py
+++ b/pisa/visualisation.py
@@ -86,9 +86,9 @@ def plot_facilities(
         - latitude: Latitude coordinate of the potential facility
         - longitude: Longitude coordinate of the potential facility
         
-    tiles : str, default="OpenStreetMap"
+    tiles : str, optional
         The tile provider for the base map. Any valid Folium tile provider name can be used.
-        See folium.Map documentation for available options.
+        See folium.Map documentation for available options. (default: "OpenStreetMap")
         
     Returns
     -------
@@ -160,9 +160,9 @@ def plot_population_heatmap(
     admin_area_boundaries : MultiPolygon or Polygon
         Shapely geometry representing the boundaries of the administrative area
         
-    tiles : str, default="OpenStreetMap"
+    tiles : str, optional
         The tile provider for the base map. Any valid Folium tile provider name can be used.
-        See folium.Map documentation for available options.
+        See folium.Map documentation for available options. (default: "OpenStreetMap")
         
     Returns
     -------
@@ -212,11 +212,11 @@ def plot_population(
         
     random_sample_n : int, optional
         Number of population points to randomly sample and display.
-        If None, all points will be displayed (may be performance-intensive for large datasets)
+        If None, all points will be displayed (may be performance-intensive for large datasets) (default: None)
         
-    tiles : str, default="OpenStreetMap"
+    tiles : str, optional
         The tile provider for the base map. Any valid Folium tile provider name can be used.
-        See folium.Map documentation for available options.
+        See folium.Map documentation for available options. (default: "OpenStreetMap")
         
     Returns
     -------
@@ -265,9 +265,9 @@ def plot_isochrones(df_isopolygons: pd.DataFrame, admin_area_boundaries: MultiPo
     admin_area_boundaries : MultiPolygon or Polygon
         Shapely geometry representing the boundaries of the administrative area
         
-    tiles : str, default="OpenStreetMap"
+    tiles : str, optional
         The tile provider for the base map. Any valid Folium tile provider name can be used.
-        See folium.Map documentation for available options.
+        See folium.Map documentation for available options. (default: "OpenStreetMap")
         
     Returns
     -------

--- a/pisa/visualisation.py
+++ b/pisa/visualisation.py
@@ -1,3 +1,27 @@
+"""Data visualization module for spatial accessibility analysis.
+
+This module provides functions for creating interactive maps and visualizations of facilities, population data,
+and isopolygons (service areas). It helps in visualizing spatial relationships between facilities and population,
+service coverage areas, and optimization scenarios.
+
+Functions
+---------
+plot_facilities : Create an interactive map showing existing and potential facilities
+plot_population : Create an interactive map showing population distribution
+plot_isochrones : Visualize isochrones/isopolygons around facilities
+plot_population_isopolygon_overlap : Visualize population points served by facility isopolygons
+plot_population_heatmap : Create a heatmap showing population density
+
+The visualizations use Folium (based on Leaflet.js) to create interactive web maps that can be
+displayed in notebooks, web applications, or exported as HTML files.
+
+See Also
+--------
+facilities : Module for facility data processing
+population : Module for population data processing
+isopolygons : Module for generating service area polygons
+"""
+
 import folium
 import numpy as np
 import pandas as pd

--- a/pisa/visualisation.py
+++ b/pisa/visualisation.py
@@ -15,8 +15,35 @@ def plot_facilities(
     df_potential_facilities: Optional[pd.DataFrame] = None,
     tiles="OpenStreetMap",
 ) -> folium.Map:
-    """Plot facilities on a map with administrative area boundaries."""
-
+    """Plot facilities on an interactive map with administrative area boundaries.
+    
+    This function creates a Folium map showing existing facilities as blue circle markers, and optionally potential 
+    facilities as orange circle markers, within the context of administrative area boundaries.
+    
+    Parameters
+    ----------
+    df_facilities : pd.DataFrame
+        DataFrame containing information about existing facilities. Must have columns:
+        - latitude: Latitude coordinate of the facility
+        - longitude: Longitude coordinate of the facility
+    
+    admin_area_boundaries : MultiPolygon or Polygon
+        Shapely geometry representing the boundaries of the administrative area
+        
+    df_potential_facilities : pd.DataFrame, optional
+        DataFrame containing information about potential facility locations. Must have columns:
+        - latitude: Latitude coordinate of the potential facility
+        - longitude: Longitude coordinate of the potential facility
+        
+    tiles : str, default="OpenStreetMap"
+        The tile provider for the base map. Any valid Folium tile provider name can be used.
+        See folium.Map documentation for available options.
+        
+    Returns
+    -------
+    folium.Map
+        Interactive Folium map with administrative boundaries and facility markers
+    """
     # Initialize the map
     start_coords = _start_coordinates_from_admin_area(admin_area_boundaries)
     folium_map = folium.Map(location=start_coords, tiles=tiles)
@@ -66,6 +93,31 @@ def plot_facilities(
 def plot_population_heatmap(
     df_population: pd.DataFrame, admin_area_boundaries: MultiPolygon | Polygon, tiles="OpenStreetMap"
 ) -> folium.Map:
+    """Create a heatmap visualization of population density.
+    
+    This function generates an interactive Folium map displaying population density as a heatmap within the specified 
+    administrative area boundaries.
+    
+    Parameters
+    ----------
+    df_population : pd.DataFrame
+        DataFrame containing population data. Must have columns:
+        - latitude: Latitude coordinate
+        - longitude: Longitude coordinate
+        - population: Population value (intensity for the heatmap)
+    
+    admin_area_boundaries : MultiPolygon or Polygon
+        Shapely geometry representing the boundaries of the administrative area
+        
+    tiles : str, default="OpenStreetMap"
+        The tile provider for the base map. Any valid Folium tile provider name can be used.
+        See folium.Map documentation for available options.
+        
+    Returns
+    -------
+    folium.Map
+        Interactive Folium map with population heatmap visualization
+    """
     start_coords = _start_coordinates_from_admin_area(admin_area_boundaries)
     folium_map = folium.Map(
         location=start_coords,
@@ -91,6 +143,35 @@ def plot_population(
     random_sample_n: Optional[int] = None,
     tiles="OpenStreetMap",
 ) -> folium.Map:
+    """Plot population points on an interactive map.
+    
+    This function creates a Folium map showing population points as circle markers, with size and opacity reflecting the 
+    relative population values.
+    
+    Parameters
+    ----------
+    df_population : pd.DataFrame
+        DataFrame containing population data. Must have columns:
+        - latitude: Latitude coordinate
+        - longitude: Longitude coordinate
+        - population: Population value at that point
+    
+    admin_area_boundaries : MultiPolygon or Polygon
+        Shapely geometry representing the boundaries of the administrative area
+        
+    random_sample_n : int, optional
+        Number of population points to randomly sample and display.
+        If None, all points will be displayed (may be performance-intensive for large datasets)
+        
+    tiles : str, default="OpenStreetMap"
+        The tile provider for the base map. Any valid Folium tile provider name can be used.
+        See folium.Map documentation for available options.
+        
+    Returns
+    -------
+    folium.Map
+        Interactive Folium map with population points displayed
+    """
     start_coords = _start_coordinates_from_admin_area(admin_area_boundaries)
     folium_map = folium.Map(
         location=start_coords,
@@ -116,6 +197,32 @@ def plot_population(
 
 
 def plot_isochrones(df_isopolygons: pd.DataFrame, admin_area_boundaries: MultiPolygon | Polygon, tiles="OpenStreetMap"):
+    """Plot isochrones/isopolygons for multiple facilities on an interactive map.
+    
+    This function creates a Folium map displaying isopolygons (areas reachable within specific travel times or distances)
+     around facilities, with different colors for each facility and varying opacity for different time/distance 
+    thresholds.
+    
+    Parameters
+    ----------
+    df_isopolygons : pd.DataFrame
+        DataFrame containing isopolygon geometries. Should have:
+        - Index representing unique facility identifiers
+        - Columns named 'ID_X' where X is the distance/time threshold (e.g., 'ID_10' for 10-minute isochrone)
+        - Each cell contains a Shapely Polygon or MultiPolygon
+    
+    admin_area_boundaries : MultiPolygon or Polygon
+        Shapely geometry representing the boundaries of the administrative area
+        
+    tiles : str, default="OpenStreetMap"
+        The tile provider for the base map. Any valid Folium tile provider name can be used.
+        See folium.Map documentation for available options.
+        
+    Returns
+    -------
+    folium.Map
+        Interactive Folium map with isopolygons visualized
+    """
     start_coords = _start_coordinates_from_admin_area(admin_area_boundaries)
     folium_map = folium.Map(
         location=start_coords,
@@ -166,6 +273,39 @@ def plot_results(
         current: pd.DataFrame,
         total_fac: pd.DataFrame,
         admin_area_boundaries: MultiPolygon | Polygon) -> folium.Map:
+    """Plot optimization results showing existing and proposed facility locations.
+    
+    This function creates a Folium map displaying the results of a facility location optimization model, showing both 
+    existing facilities and proposed new facilities.
+    
+    Parameters
+    ----------
+    open_locations : list
+        List of facility identifiers (matching indices in total_fac) that are selected as part of the optimization 
+        solution (both existing and new)
+    
+    current : pd.DataFrame
+        DataFrame containing information about existing facilities, with a column 'Cluster_ID' that identifies each 
+        facility
+        
+    total_fac : pd.DataFrame
+        DataFrame containing information about all potential facility locations (both existing and new). Must have:
+        - Index matching the identifiers in open_locations
+        - Columns 'latitude' and 'longitude' for facility coordinates
+        
+    admin_area_boundaries : MultiPolygon or Polygon
+        Shapely geometry representing the boundaries of the administrative area
+        
+    Returns
+    -------
+    folium.Map
+        Interactive Folium map showing optimization results with markers
+        
+    Notes
+    -----
+    - Existing facilities are shown with blue hospital icons
+    - Proposed new facilities are shown with purple question mark icons
+    """
     folium_map = folium.Map(
         location=(0, 0),
         zoom_start=1,
@@ -192,14 +332,50 @@ def plot_results(
 
 
 def _start_coordinates_from_admin_area(admin_area_boundaries: MultiPolygon | Polygon) -> list:
-    """Identify the start coordinates for the map."""
+    """Calculate the center coordinates for initializing a map from administrative area boundaries.
+    
+    Parameters
+    ----------
+    admin_area_boundaries : MultiPolygon or Polygon
+        Shapely geometry representing the boundaries of the administrative area
+        
+    Returns
+    -------
+    list
+        A list of [latitude, longitude] coordinates representing the centroid of the administrative area, suitable for 
+        initializing a Folium map
+        
+    Notes
+    -----
+    This function calculates the centroid of the administrative area boundaries and returns the coordinates in the 
+    format [latitude, longitude] required by Folium, which is the reverse of the standard [longitude, latitude] format 
+    used by Shapely.
+    """
     return list(admin_area_boundaries.centroid.coords)[0][::-1]
 
 
 def _bounding_box_from_admin_area(admin_area_boundaries: MultiPolygon | Polygon) -> list:
-    """Identify the bounding box for the map."""
+    """Calculate the bounding box coordinates for a map from administrative area boundaries.
+    
+    Parameters
+    ----------
+    admin_area_boundaries : MultiPolygon or Polygon
+        Shapely geometry representing the boundaries of the administrative area
+        
+    Returns
+    -------
+    list
+        A list containing two coordinate pairs in the format expected by Folium's fit_bounds method:
+        [[southwest_latitude, southwest_longitude], [northeast_latitude, northeast_longitude]]
+        
+    Notes
+    -----
+    This function extracts the bounding box coordinates from the administrative area boundaries
+    and formats them for use with Folium's fit_bounds method. The coordinates are transformed
+    from Shapely's [minx, miny, maxx, maxy] format to Folium's [[sw_lat, sw_lon], [ne_lat, ne_lon]] format.
+    """
     bounds = admin_area_boundaries.bounds
     return [
-        [bounds[1], bounds[0]],  # southwest
-        [bounds[3], bounds[2]],  # northeast
+        [bounds[1], bounds[0]],  # southwest [latitude, longitude]
+        [bounds[3], bounds[2]],  # northeast [latitude, longitude]
     ]

--- a/pisa/visualisation.py
+++ b/pisa/visualisation.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import folium
 import numpy as np
 import pandas as pd
@@ -12,7 +10,7 @@ from shapely.geometry import MultiPolygon, Polygon
 def plot_facilities(
     df_facilities: pd.DataFrame,
     admin_area_boundaries: MultiPolygon | Polygon,
-    df_potential_facilities: Optional[pd.DataFrame] = None,
+    df_potential_facilities: pd.DataFrame | None = None,
     tiles="OpenStreetMap",
 ) -> folium.Map:
     """Plot facilities on an interactive map with administrative area boundaries.
@@ -140,7 +138,7 @@ def plot_population_heatmap(
 def plot_population(
     df_population: pd.DataFrame,
     admin_area_boundaries: MultiPolygon | Polygon,
-    random_sample_n: Optional[int] = None,
+    random_sample_n: int | None = None,
     tiles="OpenStreetMap",
 ) -> folium.Map:
     """Plot population points on an interactive map.


### PR DESCRIPTION
Improve module documentation by adding comprehensive docstrings, examples, and consistent type hinting. Ensure clarity and consistency across all modules, including handling of missing values and parameters. Remove unnecessary blank lines for better readability.

Things I asked Copilot to do/check:
- [x] Type hinting
- [x] consistent setting of defaults
- [x] Examples in docstrings? Or top of modules?
- [x] Order of raises and notes sections
- [x] Docstring at top of classes vs init
- [x] Dosctrings at top of modules?
- [x] parameters or returns none: show or not?
- [x] Optional vs | none
- [x] What’s the use of “see also”?
- [x] Missing modules