### PR TITLE
Update GitHub Pages deploy action to latest version

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -48,7 +48,7 @@ jobs:
           cp -r _build/* ../gh-pages/
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: gh-pages

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -48,7 +48,7 @@ jobs:
           cp -r _build/* ../gh-pages/
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@4
         with:
           branch: gh-pages
           folder: gh-pages


### PR DESCRIPTION
Upgrade the GitHub Pages deploy action to the latest version. We were seeing a warning in the documentation deploy pipeline which was related to using an older version of the package.

<img width="1454" height="257" alt="image" src="https://github.com/user-attachments/assets/f07d886c-aab5-46df-a078-785bf4b278cd" />
